### PR TITLE
add: ci for macos

### DIFF
--- a/.github/ci/texlive.profile
+++ b/.github/ci/texlive.profile
@@ -1,0 +1,15 @@
+# From latex3 & fduthesis
+# https://github.com/latex3/latex3/blob/main/support/texlive.profile
+# https://github.com/stone-zeng/fduthesis/blob/main/.github/workflows/texlive.profile
+
+selected_scheme     scheme-infraonly
+TEXDIR              /tmp/texlive
+TEXMFSYSCONFIG      /tmp/texlive/texmf-config
+TEXMFSYSVAR         /tmp/texlive/texmf-var
+TEXMFLOCAL          /tmp/texlive/texmf-local
+TEXMFHOME           ~/texmf
+TEXMFCONFIG         ~/.texlive/texmf-config
+TEXMFVAR            ~/.texlive/texmf-var
+option_doc          0
+option_src          0
+tlpdbopt_autobackup 0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,33 +9,65 @@ on:
 
 name: test
 
+env:
+  # gbt7714 natbib: gbt7714 needed
+  # chinese-jfm: lualatex needed
+  # catchfile fancyvrb framed fvextra ifplatform lineno minted pdftexcmds upquote xstring: minted needed
+  # biber biblatex bibtex: for executable bibtex
+  # txfonts: mathptmx is obsoleted; times: times is obsoleted but utmb8a.pfb is needed
+  # dvips: for 8r.enc, OS X needed; gsftopk: command needed when xdv -> pdf
+  TL_PACKAGES: adjustbox algorithmicx algorithms caption cases chngcntr collectbox ctex enumitem environ extarrows fancybox fancyhdr float lastpage latexmk multirow needspace rsfs setspace subfigure tcolorbox texcount texliveonfly titling tocloft trimspaces ucs xcolor xecjk zhnumber gbt7714 natbib chinese-jfm catchfile fancyvrb framed fvextra ifplatform lineno minted pdftexcmds upquote xstring txfonts times biber biblatex bibtex dvips gsftopk
+
 jobs:
-  build-xelatex:
+  build-ubuntu:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [-xelatex, -lualatex]
     steps:
       - name: checkout
         uses: actions/checkout@v2
       - name: compile LaTeX document
         uses: xu-cheng/texlive-action/full@v1
         with:
-          run: "latexmk -xelatex -interaction=nonstopmode -file-line-error -halt-on-error -shell-escape main"
+          run: |
+            latexmk ${{ matrix.compiler }} -interaction=nonstopmode -file-line-error -halt-on-error -shell-escape main
       - name: upload pdf
         uses: actions/upload-artifact@v2
         with:
-          name: document output
+          name: document linux output
           path: main.pdf
 
-  build-lualatex:
-    runs-on: ubuntu-latest
+  build-macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        compiler: [-xelatex, -lualatex]
+    env:
+      SET_PATH: export PATH=/tmp/texlive/bin/universal-darwin:/usr/texbin:$PATH
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: compile LaTeX document
-        uses: xu-cheng/texlive-action/full@v1
+      - name: install Python for minted
+        uses: actions/setup-python@v4
         with:
-          run: "latexmk -lualatex -interaction=nonstopmode -file-line-error -halt-on-error -shell-escape main"
+          python-version: '3.9'
+      - name: pip install Pygments for minted
+        run: pip install Pygments
+      - name: install TeXLive
+        run: |
+          ${{ env.SET_PATH }}
+          curl -O https://mirrors.rit.edu/CTAN/systems/texlive/tlnet/install-tl-unx.tar.gz
+          tar -xzf install-tl-unx.tar.gz
+          cd install-tl-20* && ./install-tl --profile ../.github/ci/texlive.profile
+          tlmgr install ${{ env.TL_PACKAGES }}
+          tlmgr update --self --all --no-auto-install --repository=https://mirrors.rit.edu/CTAN/systems/texlive/tlnet/
+          tlmgr path add
+      - name: compile LaTeX document
+        run: |
+          latexmk ${{ matrix.compiler }} -interaction=nonstopmode -file-line-error -halt-on-error -shell-escape main
       - name: upload pdf
         uses: actions/upload-artifact@v2
         with:
-          name: document output
+          name: document macos output
           path: main.pdf

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,11 @@
 on:
   push:
     branches:
-      - main
+      - master
       - fix-ci
   pull_request:
     branches:
-      - main
+      - master
 
 name: test
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -27,31 +27,15 @@ Note that **the overleaf template might not be up-to-date** so it is suggested t
 ## Compile it locally on Mac/Linux/Windows
 
 ```shell
-# Install BasicTex: https://mirrors.chevalier.io/CTAN/systems/mac/mactex/mactex-basictex-20210325.pkg
+# The following commands aims at installing packages upon TeXLive without any packages.
+# You can also install BasicTex: https://mirrors.chevalier.io/CTAN/systems/mac/mactex/mactex-basictex-20210325.pkg
 sudo tlmgr update --self
 
-sudo tlmgr install texliveonfly
-sudo tlmgr install latexmk
-sudo tlmgr install adjustbox
-sudo tlmgr install tcolorbox
-sudo tlmgr install collectbox
-sudo tlmgr install ucs
-sudo tlmgr install environ
-sudo tlmgr install titling
-sudo tlmgr install enumitem
-sudo tlmgr install rsfs
-sudo tlmgr install tocloft
-sudo tlmgr install xcolor
-sudo tlmgr install trimspaces
-sudo tlmgr install zhnumber
-sudo tlmgr install ctex
-sudo tlmgr install texcount
-sudo tlmgr install needspace
-sudo tlmgr install xecjk
-sudo tlmgr install subfigure
-sudo tlmgr install cases
-sudo tlmgr install algorithms
-sudo tlmgr install multirow
+sudo tlmgr install adjustbox algorithm \
+    cases caption chngcntr collectbox ctex enumerate enumitem environ extarrows fancybox fancyhdr \
+    lastpage latexmk longtable mathptmx minted multirow needspace rsfs setspace subfigure \
+    tcolorbox texcount texliveonfly tikz titling \
+    tocloft trimspaces ucs verbatim xcolor xecjk zhnumber
 
 sudo tlmgr update --self --all
 ```
@@ -143,7 +127,8 @@ Initial template provided by [YukuanHU](https://github.com/YukuanHu), maintained
 
 We learned a lot from the leading university open-source repositories:
 
-* https://github.com/sjtug/SJTUThesis (makefile & batchfile)
+* [sjtug/SJTUThesis](https://github.com/sjtug/SJTUThesis): makefile & batchfile
+* [stone-zeng/fduthesis](https://github.com/stone-zeng/fduthesis): workflows
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@
 
 #### i. 使用 tlmgr
 
-通过 [此处](https://tug.org/texlive/acquire.html) 下载 TeXLive，并使用 `tlmgr` 下载宏包：
+下载 TeXLive，并使用 `tlmgr` 下载宏包：
 
 ```shell
-# Install BasicTex: https://mirrors.chevalier.io/CTAN/systems/mac/mactex/mactex-basictex-20210325.pkg
+# The following commands aims at installing packages upon TeXLive without any packages.
+# You can also install BasicTex: https://mirrors.chevalier.io/CTAN/systems/mac/mactex/mactex-basictex-20210325.pkg
 sudo tlmgr update --self
 
 sudo tlmgr install adjustbox algorithm \
@@ -118,6 +119,12 @@ make wordcount                # wordcount
 * 点击左侧边栏中带有 TEX 图标的 LaTeX 按钮；
 * 点击 `Build LaTeX project` 列表中的 `Recipe: latexmk (xelatex)` 编译 `.pdf` 文件。
 
+### 6. 在 GitHub Actions 中编译
+
+项目以 `.github/workflows/*.yaml` 配置了 GitHub Actions，push 代码到 fork 仓库或 template-generated 仓库均可触发测试。可通过 commit 对应的 workflow run 中的 `Summary | Artifacts` 获得多平台构建产物。
+
+（通过勾选 `Settings | Actions | General | Allow all actions and reusable workflows` 打开 GitHub Actions）
+
 ## 如何为该项目贡献代码？
 
 还请查看 [How to pull request](CONTRIBUTING.md/#how-to-pull-request)。
@@ -151,6 +158,7 @@ by Sam Hocevar <sam@hocevar.net>
 我们从顶尖高校的优秀开源项目中学到了很多：
 
 * [sjtug/SJTUThesis](https://github.com/sjtug/SJTUThesis): makefile & batchfile
+* [stone-zeng/fduthesis](https://github.com/stone-zeng/fduthesis): workflows
 
 ## 联系方式
 

--- a/README.md
+++ b/README.md
@@ -34,28 +34,11 @@
 # Install BasicTex: https://mirrors.chevalier.io/CTAN/systems/mac/mactex/mactex-basictex-20210325.pkg
 sudo tlmgr update --self
 
-sudo tlmgr install texliveonfly
-sudo tlmgr install latexmk
-sudo tlmgr install adjustbox
-sudo tlmgr install tcolorbox
-sudo tlmgr install collectbox
-sudo tlmgr install ucs
-sudo tlmgr install environ
-sudo tlmgr install titling
-sudo tlmgr install enumitem
-sudo tlmgr install rsfs
-sudo tlmgr install tocloft
-sudo tlmgr install xcolor
-sudo tlmgr install trimspaces
-sudo tlmgr install zhnumber
-sudo tlmgr install ctex
-sudo tlmgr install texcount
-sudo tlmgr install needspace
-sudo tlmgr install xecjk
-sudo tlmgr install subfigure
-sudo tlmgr install cases
-sudo tlmgr install algorithms
-sudo tlmgr install multirow
+sudo tlmgr install adjustbox algorithm \
+    cases caption chngcntr collectbox ctex enumerate enumitem environ extarrows fancybox fancyhdr \
+    lastpage latexmk longtable mathptmx minted multirow needspace rsfs setspace subfigure \
+    tcolorbox texcount texliveonfly tikz titling \
+    tocloft trimspaces ucs verbatim xcolor xecjk zhnumber
 
 sudo tlmgr update --self --all
 ```

--- a/style/tongjithesis.sty
+++ b/style/tongjithesis.sty
@@ -3,11 +3,10 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % 数学符号
-% mathptmx 定义了 Adobe Times Roman 字体，
-% 同时提供了字体应用在数学环境中的支持
-% see https://ctan.org/pkg/mathptmx?lang=en
-\usepackage{mathptmx}
+% 使用更现代的 newtx
+% see https://tex.stackexchange.com/questions/56876/times-new-roman-fonts-and-maths-without-mathptmx
 \usepackage{amsmath,amsthm,amsfonts,amssymb,amscd}
+\usepackage{txfonts}
 \theoremstyle{definition}
 \newtheorem{thm}{定理\hspace{0.05pt}}[section]
 \newtheorem{cor}{推论\hspace{0.05pt}}[section]


### PR DESCRIPTION
## 对该 PR 的总结

<!--感谢同学的贡献，还希望在此处通过 “无序列表” 的方式列出该 PR 所做的工作-->

* 参照 [fduthesis](https://github.com/stone-zeng/fduthesis) 增加了 MacOS 的 workflow；
* 修改了对应的 README。

### 该 PR 的成功合入是否需要关闭一些 Issue？

Close #14 

<!--还请使用 “Close #id” 的方式给出-->

### 该 PR 的功能展示

<!--如果该 PR 与 “模板功能特性” 相关且较为方便的话，那么还请给出 PR 合入后对编译产物的影响。例如，可以上传一些图片-->

![image](https://user-images.githubusercontent.com/45269589/173548441-5cbe1afe-26ff-4e00-816d-d604d0f71cd4.png)

### 该 PR 的其他信息

<!--这里用于提出其他与该 PR 相关的信息-->

workflow 中是参照 fduthesis 从 install-tl 开始的，或许之后可以改成 Basic。