### PR TITLE
fix: default math font; ci; README

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ env:
   # biber biblatex bibtex: for executable bibtex
   # txfonts: mathptmx is obsoleted; times: times is obsoleted but utmb8a.pfb is needed
   # dvips: for 8r.enc, OS X needed; gsftopk: command needed when xdv -> pdf
-  TL_PACKAGES: adjustbox algorithmicx algorithms biber biblatex bibtex booktabs caption carlisle cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips enumitem environ extarrows fancybox fancyhdr fancyvrb float framed fvextra gbt7714 gsftopk helvetic hologo ifplatform lastpage latexmk lineno minted multirow mwe natbib needspace newtx nth oberdiek pdftexcmds realscripts rsfs setspace siunitx subfig tcolorbox texcount texliveonfly threeparttable threeparttablex times titling tocloft trimspaces ucs upquote was xcolor xecjk xstring zhnumber
+  TL_PACKAGES: adjustbox algorithmicx algorithms biber biblatex bibtex booktabs caption carlisle cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips enumitem environ extarrows fancybox fancyhdr fancyvrb float framed fvextra gbt7714 gsftopk helvetic hologo ifplatform lastpage latexmk lineno minted multirow mwe natbib needspace newtx nth oberdiek pdftexcmds realscripts rsfs setspace siunitx subfig tcolorbox texcount texliveonfly threeparttable threeparttablex times titling tocloft trimspaces txfonts ucs upquote was xcolor xecjk xstring zhnumber
 
 jobs:
   build-linux:

--- a/README-EN.md
+++ b/README-EN.md
@@ -70,10 +70,10 @@ Download TeXLive and use `tlmgr` to download packages:
 sudo tlmgr update --self
 
 sudo tlmgr install adjustbox algorithmicx algorithms biber biblatex bibtex booktabs \ 
-    caption cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips \ 
+    caption carlisle cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips \ 
     enumitem environ extarrows fancybox fancyhdr fancyvrb float framed fvextra \ 
     gbt7714 gsftopk helvetic hologo ifplatform lastpage latexmk lineno \ 
-    minted multirow mwe natbib needspace nth pdftexcmds rsfs setspace siunitx subfig \
+    minted multirow mwe natbib needspace newtx nth oberdiek pdftexcmds realscripts rsfs setspace siunitx subfig \
     tcolorbox texcount texliveonfly threeparttable threeparttablex times titling tocloft \ 
     trimspaces txfonts ucs upquote was xcolor xecjk xstring zhnumber
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ pip install Pygments
 sudo tlmgr update --self
 
 sudo tlmgr install adjustbox algorithmicx algorithms biber biblatex bibtex booktabs \ 
-    caption cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips \ 
+    caption carlisle cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips \ 
     enumitem environ extarrows fancybox fancyhdr fancyvrb float framed fvextra \ 
     gbt7714 gsftopk helvetic hologo ifplatform lastpage latexmk lineno \ 
-    minted multirow mwe natbib needspace nth pdftexcmds rsfs setspace siunitx subfig \
+    minted multirow mwe natbib needspace newtx nth oberdiek pdftexcmds realscripts rsfs setspace siunitx subfig \
     tcolorbox texcount texliveonfly threeparttable threeparttablex times titling tocloft \ 
     trimspaces txfonts ucs upquote was xcolor xecjk xstring zhnumber
 


### PR DESCRIPTION
## Summary of this PR

Several users of our codebase have raised inquiries regarding math fonts. They have observed discrepancies between the math fonts utilized in this template and the purported "default" math fonts.

Consequently, I have made modifications to the following code:

```tex
\usepackage{ifthen}
\newboolean{useTimesNewRoman}
\setboolean{useTimesNewRoman}{false} % Set to false if you don't want to use Times New Roman 
                                     % or if you want to use the default math font (Latin Modern) for math symbols
\ifthenelse{\boolean{useTimesNewRoman}}{%
  \usepackage{amsmath,amsthm,amsfonts,amssymb,amscd}%
  \usepackage{fontspec}%
  \setmainfont{Times New Roman}%
}{%
  \usepackage{amsthm,amscd}%
  \usepackage{newtxtext,newtxmath}%
}
```

Hence, as indicated in the comments, if you desire to employ `Times New Roman` instead of `Adobe New Roman`, **or** if you wish to utilize the "default" math font, you can set the `useTimesNewRoman` variable to true.

If you have any suggestions or questions, please feel free to share them in the GitHub Discussions.

### Should the successful integration of this PR lead to the closure of certain issues?

The specific issues discussed privately on QQ. In the future, it would be preferable to address such matters through GitHub Discussions. 👍🏻

