### PR TITLE
Update: instructions for specifying Python path manually

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -100,7 +100,7 @@ make wordcount                # wordcount
 
 2. Run the Python installer: Double-click the downloaded installer and follow the prompts to install it. During installation, remember to check the `Add Python 3.x to PATH` option so that Python can be used from the command line.
 
-#### ii. Install `pygmentize` using `pip`
+#### ii. Install `pygments` using `pip`
 
 Enter the following command in the terminal:
 ```shell
@@ -109,9 +109,15 @@ pip install Pygments
 
 Note: If you encounter permissions problems during the installation process, you can run the above command from a command prompt with administrator privileges.
 
+Note: If you are concerned about the potential environmental contamination risks of adding a specific version of Python to your environment paths and wish to use a Python environment manager application, proceed as follows:
+- Create a new Python environment and install the `pygments` module.
+- Follow the comments in `main.tex` which specify the environment path directly in the file.
+
 #### iii. Install TeXLive
 
 Download `install-tl-windows.exe` from [here](https://www.tug.org/texlive/acquire-netinstall.html).
+
+Note: A data pack of about 8GB will be downloaded during the installation process, please be patient.
 
 #### iv. Build the project through Batchfile
 
@@ -128,6 +134,8 @@ You can complete the corresponding operation with the following command:
 .\make.bat wordcount            # wordcount
 .\make.bat help                 # read the manual
 ```
+
+At this point, you are ready to write your paper with LaTex. If you prefer to operate in a full UI environment rather than the command line, please continue with the following.
 
 ### 5. Using on VSCode
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ make wordcount                # wordcount
 
 2. 运行 Python 安装程序：双击下载的安装程序并按照提示进行安装。在安装过程中，记得勾选 `Add Python 3.x to PATH` 选项，这样 Python 才能在命令行中使用。
 
-#### ii. 使用 `pip` 安装 `pygmentize`
+#### ii. 使用 `pip` 安装 `pygments`
 
 在终端中输入以下命令：
 ```shell
@@ -113,9 +113,15 @@ pip install Pygments
 
 注意：如果你在安装过程中遇到了权限问题，可以在命令提示符中使用管理员权限运行以上命令。
 
+注意：若您担忧将某个具体版本的 Python 加入环境变量存在潜在的环境污染隐患，希望使用 Python 环境管理应用，则步骤如下：
+- 创建一个新的 Python 环境，在环境中安装 `pygments` 模块
+- 按照`main.tex`中的注释，在文件中直接指定该环境路径。
+
 #### iii. 安装 TeXLive
 
 通过 [此处](https://www.tug.org/texlive/acquire-netinstall.html) 下载 `install-tl-windows.exe`。
+
+注意：安装过程中会下载8GB左右的数据，请耐心等待。
 
 #### iv. 通过 Batchfile 构建项目
 
@@ -132,6 +138,8 @@ pip install Pygments
 .\make.bat wordcount            # wordcount
 .\make.bat help                 # read the manual
 ```
+
+至此，您已经可以借助LaTex撰写论文了。若相比命令行，您更倾向于在一个完整的UI环境中进行操作，请继续查阅以下内容。
 
 ### 5. 在 VSCode 上使用
 

--- a/main.tex
+++ b/main.tex
@@ -9,6 +9,16 @@
 % \newcommand{。}{\ifmmode\text{．}\else ．\fi}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% 在Windows上使用时：
+% 若你想避免将 Python 加入环境变量，可以在此手动指定python环境
+% 打开下面的注释，并替换尖括号<>中的路径
+% e.g. {<X:/your/path/to/python>/python.exe} -> {C:/software/Anaconda3/envs/latex/python.exe}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% \newcommand{\myPython}{<X:/your/path/to/python>/python.exe}
+% \renewcommand{\MintedPygmentize}{\myPython\space -m pygments}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \begin{document}
 
 \input{sections/frontcover.tex}


### PR DESCRIPTION
## 对该 PR 的总结
- 在`main.tex`和README中添加了（Windows下）关于如何手动指定 Python 的路径的说明。
- 将标题`使用 pip 安装 pygmentize`中的`pygmentize`改为`pygments`。因为安装`Pygments`库后，在python中的依赖方式为`import pygments`。`pygmentize`是安装该库过程中产生的可执行文件，在用户使用本项目时并不会显式地出现此词（除log文件外）。
