### PR TITLE
ci: update binaries path in TL 2023

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,7 @@ jobs:
       matrix:
         compiler: [-xelatex, -lualatex]
     env:
-      SET_PATH: ${env:PATH} = "${{ github.workspace }}\tmp\texlive\bin\win32;" + ${env:PATH}
+      SET_PATH: ${env:PATH} = "${{ github.workspace }}\tmp\texlive\bin\windows;" + ${env:PATH}
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## 对该 PR 的总结

<!--感谢同学的贡献，还希望在此处通过 “无序列表” 的方式列出该 PR 所做的工作-->

修复因二进制文件路径修改而导致的 ci 不通过问题。

### 该 PR 的成功合入是否需要关闭一些 Issue？

<!--还请使用 “Close #id” 的方式给出-->

Close #27 
