### PR TITLE
update: twoside init

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -188,6 +188,10 @@ The project has been configured with GitHub Actions in `.github/workflows/*.yaml
 
 See [tongji-undergrad-thesis-env](https://github.com/TJ-CSCCG/tongji-undergrad-thesis-env) for detailed instructions.
 
+## Use double-sided printing version (optional)
+
+If you need to use the two-sided printing version, please change `\documentclass[oneside]{tongjithesis}` to `\documentclass[twoside]{tongjithesis}` in line 1 of `main.tex`.
+
 ## Use more complete Adobe fonts (optional)
 
 ### Style modification

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ pip install Pygments
 
 详细使用方法见 [tongji-undergrad-thesis-env](https://github.com/TJ-CSCCG/tongji-undergrad-thesis-env)。
 
+## 使用双面打印版（可选）
+
+如果您需要使用双面打印版，请在 `main.tex` 中将第 1 行的 `\documentclass[oneside]{tongjithesis}` 修改为 `\documentclass[twoside]{tongjithesis}`。
+
 ## 使用字库更完整的 Adobe 字体（可选）
 
 ### 样式修改

--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,4 @@
-\documentclass{tongjithesis}
+\documentclass[oneside]{tongjithesis}
 \usepackage{tongjithesis}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -23,12 +23,34 @@
 
 \input{sections/frontcover.tex}
 
+\makeatletter
+\@ifclasswith{tongjithesis}{twoside}{%
+  \cleardoublepage
+}{%
+  \clearpage
+}
+\makeatother
+
 \pagestyle{firststyle}
 \input{sections/00_abstract.tex}
 
+\makeatletter
+\@ifclasswith{tongjithesis}{twoside}{%
+\cleardoublepage
+}{%
 \clearpage
+}
+\makeatother
+
 \tableofcontents   %放置目录
+
+\makeatletter
+\@ifclasswith{tongjithesis}{twoside}{%
+\cleardoublepage
+}{%
 \clearpage
+}
+\makeatother
 
 \pagestyle{mainstyle}
 \input{sections/01_intro}

--- a/main.tex
+++ b/main.tex
@@ -25,9 +25,9 @@
 
 \makeatletter
 \@ifclasswith{tongjithesis}{twoside}{%
-  \cleardoublepage
+\cleardoublepage
 }{%
-  \clearpage
+\clearpage
 }
 \makeatother
 

--- a/sections/00_abstract.tex
+++ b/sections/00_abstract.tex
@@ -6,6 +6,13 @@
     关键词1，关键词2，关键词3通常是与文章内容相关的几个词语，用于帮助读者更好地了解文章主题和内容。关键词的选择应该与文章的主题和研究领域密切相关，通常应该选择具有代表性、权威性、独特性和可搜索性的词语。
 }{关键词1，关键词2，关键词3}
 
+\makeatletter
+\@ifclasswith{tongjithesis}{twoside}{%
+  \cleardoublepage
+}{%
+}
+\makeatother
+
 \MakeAbstractEng{
     An abstract is usually a short summary of an article, essay, report, or other text. Its purpose is to help the reader understand the main content and conclusions of the text so that he or she can decide whether he or she needs to continue reading the original text. The abstract usually contains information about the topic, purpose, methods, results, and conclusions of the text and is presented as concisely and clearly as possible. A good abstract should be able to summarize the main points of the text while avoiding unnecessary details and jargon so that it can be easily understood by a wide audience.
 

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -22,8 +22,54 @@
 \RequirePackage[a4paper,top=4.2cm,bottom=2.7cm,left=3.3cm,right=1.8cm]{geometry}
 
 
+% 重新定义 \cleardoublepage 命令
+\let\origdoublepage\cleardoublepage
+\newcommand{\clearemptydoublepage}{
+	\clearpage
+	{\pagestyle{empty}\origdoublepage}
+}
+\let\cleardoublepage\clearemptydoublepage
+
+
 % 画边界线
 \RequirePackage{fancybox}
+
+\makeatletter
+\@ifclasswith{tongjithesis}{twoside}{%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-4.3cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-4.9cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-5.5cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-6.1cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-6.7cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-7.3cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-7.9cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-8.5cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-9.1cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-9.7cm){$|$}%
+\fancyput*(\ifodd\value{page} -1.0cm\else 16.5cm\fi,-10.3cm){装}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-10.9cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-11.5cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-12.1cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-12.7cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-13.3cm){$|$}%
+\fancyput*(\ifodd\value{page} -1.0cm\else 16.5cm\fi,-13.9cm){订}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-14.5cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-15.1cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-15.7cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-16.3cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-16.9cm){$|$}%
+\fancyput*(\ifodd\value{page} -1.0cm\else 16.5cm\fi,-17.5cm){线}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-18.1cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-18.7cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-19.3cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-19.9cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-20.5cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-21.1cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-21.7cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-22.3cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-22.9cm){$|$}%
+\fancyput*(\ifodd\value{page} -0.8cm\else 16.7cm\fi,-23.5cm){$|$}%
+}{%
 \fancyput*(-0.8cm,-4.3cm){$|$}%
 \fancyput*(-0.8cm,-4.9cm){$|$}%
 \fancyput*(-0.8cm,-5.5cm){$|$}%
@@ -57,7 +103,8 @@
 \fancyput*(-0.8cm,-22.3cm){$|$}%
 \fancyput*(-0.8cm,-22.9cm){$|$}%
 \fancyput*(-0.8cm,-23.5cm){$|$}%
-
+}
+\makeatother
 
 % 设置有序列表与无序列表格式
 \RequirePackage{enumerate} % 下面用到了 enumerate
@@ -135,8 +182,8 @@
 \fancypagestyle{firststyle}{
 	\fancyhf{}
 	\pagenumbering{Roman}                    	% 页数使用罗马数字
-	\fancyhead[L]{\qquad \includegraphics[height=1.14cm]{figures/tongji.pdf}}   %页眉左侧插入同济大学logo
-	\fancyhead[R]{\large 毕业设计（论文）~\\}
+\fancyhead[LO,RE]{\qquad \includegraphics[height=1.14cm]{figures/tongji.pdf}}   %页眉左侧插入同济大学logo
+\fancyhead[RO,LE]{\large 毕业设计（论文）~\\}
 	\fancyfoot[C]{\large \thepage}
 	\renewcommand{\headrulewidth}{1.8pt}     	% 页眉横线
 	\renewcommand{\footrulewidth}{0pt}
@@ -148,9 +195,10 @@
 \fancypagestyle{mainstyle}{
 	\fancyhf{}
 	\pagenumbering{arabic}
-	\fancyhead[L]{\qquad \includegraphics[height=1.14cm]{figures/tongji.pdf}}   %页眉左侧插入同济大学logo
-	\fancyhead[R]{\large 毕业设计（论文）~\\}
-	\fancyfoot[R]{{\large 共\quad \pageref{LastPage}\quad 页\quad 第\quad \thepage \quad 页}} %偶数页左侧(LE)，奇数页右侧(RO)标页码，oneside打印只用写RO
+\fancyhead[LO,RE]{\qquad \includegraphics[height=1.14cm]{figures/tongji.pdf}}   %页眉左侧插入同济大学logo
+\fancyhead[RO,LE]{\large 毕业设计（论文）~\\}
+\fancyfoot[RO]{{\large 共\quad \pageref{LastPage}\quad 页\quad 第\quad \thepage \quad 页}}
+\fancyfoot[LE]{{\large 第\quad \thepage \quad 页\quad 共\quad \pageref{LastPage}\quad 页}}
 	\renewcommand{\headrulewidth}{1.8pt}     	% 页眉横线
 	\renewcommand{\footrulewidth}{1.8pt}     	% 页脚横线
 }


### PR DESCRIPTION
## 对该 PR 的总结

针对计算机系突然发布的有关“归档上交的纸质版论文必须为双面打印”的通知，我们迅速采取行动，紧急制作了双面打印版本，以供各位选择使用。

如果您需要使用双面打印版，请在 `main.tex` 中将第 1 行的 

```latex
\documentclass[oneside]{tongjithesis}
```

修改为 

```latex
\documentclass[twoside]{tongjithesis}
```

### 该 PR 的功能展示

![main-09](https://github.com/TJ-CSCCG/tongji-undergrad-thesis/assets/59563695/53e8482b-0f25-4986-9936-b8ee4ceaf702)

![main-10](https://github.com/TJ-CSCCG/tongji-undergrad-thesis/assets/59563695/0f0e11cc-d9ac-46e4-92dd-1a71504cf7cd)
