### PR TITLE
Add dynamically scaled cover items

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ env:
   # biber biblatex bibtex: for executable bibtex
   # txfonts: mathptmx is obsoleted; times: times is obsoleted but utmb8a.pfb is needed
   # dvips: for 8r.enc, OS X needed; gsftopk: command needed when xdv -> pdf
-  TL_PACKAGES: adjustbox algorithmicx algorithms biber biblatex biblatex-gb7714-2015 bibtex booktabs caption carlisle cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips enumitem environ extarrows fancybox fancyhdr fancyvrb float framed fvextra gbt7714 gsftopk helvetic hologo ifplatform lastpage latex-tools latexmk lineno minted multirow mwe natbib needspace newtx nth oberdiek pdftexcmds realscripts rsfs setspace siunitx subfig tcolorbox texcount texliveonfly threeparttable threeparttablex times titling tocloft trimspaces txfonts ucs upquote was xcolor xecjk xpatch xstring zhnumber
+  TL_PACKAGES: adjustbox algorithmicx algorithms biber biblatex biblatex-gb7714-2015 bibtex booktabs caption carlisle cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips enumitem environ extarrows fancybox fancyhdr fancyvrb float framed fvextra gbt7714 gsftopk helvetic hologo ifplatform lastpage latexmk lineno minted multirow mwe natbib needspace newtx nth oberdiek pdftexcmds realscripts rsfs setspace siunitx subfig tcolorbox texcount texliveonfly threeparttable threeparttablex times titling tocloft trimspaces txfonts ucs upquote was xcolor xecjk xpatch xstring zhnumber
 
 jobs:
   build-linux:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ env:
   # biber biblatex bibtex: for executable bibtex
   # txfonts: mathptmx is obsoleted; times: times is obsoleted but utmb8a.pfb is needed
   # dvips: for 8r.enc, OS X needed; gsftopk: command needed when xdv -> pdf
-  TL_PACKAGES: adjustbox algorithmicx algorithms biber biblatex biblatex-gb7714-2015 bibtex booktabs calc caption carlisle cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips enumitem environ extarrows fancybox fancyhdr fancyvrb float framed fvextra gbt7714 gsftopk helvetic hologo ifplatform lastpage latexmk lineno minted multirow mwe natbib needspace newtx nth oberdiek pdftexcmds realscripts rsfs setspace siunitx subfig tcolorbox texcount texliveonfly threeparttable threeparttablex times titling tocloft trimspaces txfonts ucs upquote was xcolor xecjk xpatch xstring zhnumber
+  TL_PACKAGES: adjustbox algorithmicx algorithms biber biblatex biblatex-gb7714-2015 bibtex booktabs caption carlisle cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips enumitem environ extarrows fancybox fancyhdr fancyvrb float framed fvextra gbt7714 gsftopk helvetic hologo ifplatform lastpage latex-tools latexmk lineno minted multirow mwe natbib needspace newtx nth oberdiek pdftexcmds realscripts rsfs setspace siunitx subfig tcolorbox texcount texliveonfly threeparttable threeparttablex times titling tocloft trimspaces txfonts ucs upquote was xcolor xecjk xpatch xstring zhnumber
 
 jobs:
   build-linux:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ env:
   # biber biblatex bibtex: for executable bibtex
   # txfonts: mathptmx is obsoleted; times: times is obsoleted but utmb8a.pfb is needed
   # dvips: for 8r.enc, OS X needed; gsftopk: command needed when xdv -> pdf
-  TL_PACKAGES: adjustbox algorithmicx algorithms biber biblatex biblatex-gb7714-2015 bibtex booktabs caption carlisle cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips enumitem environ extarrows fancybox fancyhdr fancyvrb float framed fvextra gbt7714 gsftopk helvetic hologo ifplatform lastpage latexmk lineno minted multirow mwe natbib needspace newtx nth oberdiek pdftexcmds realscripts rsfs setspace siunitx subfig tcolorbox texcount texliveonfly threeparttable threeparttablex times titling tocloft trimspaces txfonts ucs upquote was xcolor xecjk xpatch xstring zhnumber
+  TL_PACKAGES: adjustbox algorithmicx algorithms biber biblatex biblatex-gb7714-2015 bibtex booktabs calc caption carlisle cases catchfile chinese-jfm chngcntr cleveref collectbox ctex dvips enumitem environ extarrows fancybox fancyhdr fancyvrb float framed fvextra gbt7714 gsftopk helvetic hologo ifplatform lastpage latexmk lineno minted multirow mwe natbib needspace newtx nth oberdiek pdftexcmds realscripts rsfs setspace siunitx subfig tcolorbox texcount texliveonfly threeparttable threeparttablex times titling tocloft trimspaces txfonts ucs upquote was xcolor xecjk xpatch xstring zhnumber
 
 jobs:
   build-linux:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: install Python for minted
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: pip install Pygments for minted
         run: pip install Pygments
       - name: install TeXLive
@@ -97,7 +97,7 @@ jobs:
       - name: install Python for minted
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: pip install Pygments for minted
         run: pip install Pygments
       - name: install TeXLive

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -295,7 +295,7 @@
 }{\renewcommand{\arraystretch}{1.2}\endoldtabular
 }
 
-\RequirePackage{ulem}
+\RequirePackage{ulem,calc}
 \newlength{\covertextwidth}
 \newlength{\covermaxwidth}
 

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -272,9 +272,9 @@
 
 % 设置参考文献格式
 \RequirePackage[
-    backend=biber,
-    style=gb7714-2015,
-    natbib=true,
+	backend=biber,
+	style=gb7714-2015,
+	natbib=true,
 ]{biblatex}
 \addbibresource{bib/note.bib}
 
@@ -294,8 +294,22 @@
 	\zihao{-3}\oldtabular[#1]
 }{\renewcommand{\arraystretch}{1.2}\endoldtabular
 }
+
 \RequirePackage{ulem}
-\newcommand{\ulinecentered}[1]{\uline{\makebox[20em][c]{#1}}}
+\newlength{\covertextwidth}
+\newlength{\covermaxwidth}
+
+\newcommand{\ulinecentered}[1]{
+	\setlength{\covertextwidth}{\widthof{#1}}
+	\setlength{\covermaxwidth}{20em} % Set the maximum width you allow
+	\ifthenelse{\lengthtest{\covertextwidth > \covermaxwidth}}{
+		% Calculate scale factor and scale down text if too wide
+		\pgfmathsetmacro{\scalefactor}{\covermaxwidth/\covertextwidth}
+		\uline{\makebox[\covermaxwidth][c]{\scalebox{\scalefactor}[1]{#1}}}
+	}{
+		\uline{\makebox[\covermaxwidth][c]{#1}} % Use normal text if within the limit
+	}
+}
 
 
 % 加载包部分结束，此后开始定义内容 Layout
@@ -398,10 +412,10 @@
 
 \makeatletter
 \def\clearchapterpage{%
-  \@ifclasswith{tongjithesis}{twoside}{%
-    \cleardoublepage % 如果使用双面模式的 tongjithesis 文档类，使用 \cleardoublepage 清除页面
-  }{%
-    \clearpage % 否则，使用 \clearpage 清除页面
-  }
+	\@ifclasswith{tongjithesis}{twoside}{%
+		\cleardoublepage % 如果使用双面模式的 tongjithesis 文档类，使用 \cleardoublepage 清除页面
+	}{%
+		\clearpage % 否则，使用 \clearpage 清除页面
+	}
 }
 \makeatother


### PR DESCRIPTION
## PR 的总结

由于部分学生的论文标题长度超出了毕业论文模板封面的单行容纳能力，此 PR 旨在对封面上的长标题（包括副标题等）进行缩放，使其与封面提供的下划线等宽。考虑到正式提交的论文会包括一份手写封面，故此模板中的封面仅用作占位和示意，长标题问题也仅影响部分学生，基于此，我们引入了此项调整。

### 是否需通过此 PR 关闭相关 Issue？

关闭 Issue #42

### PR 功能展示

![WX20240425-161159@2x](https://github.com/TJ-CSCCG/tongji-undergrad-thesis/assets/59563695/cda8deb4-826e-4dc1-ad6e-d3240676a2eb)

### 其他相关信息

#42 #43