### PR TITLE
fix: 信息说明页多行标题间距、规范行距对齐与元数据整合

### DIFF
--- a/chapters/frontcover.tex
+++ b/chapters/frontcover.tex
@@ -1,9 +1,0 @@
-\school{计算机科学与技术学院}
-\major{计算机科学与技术}
-\student{2654321}{张同舟}
-\thesistitle{\TongjiThesis{} 论文模板使用示例}{\LaTeX{}排版技术在学术写作中的应用}
-\thesistitleeng{\TongjiThesis{} Template Usage Example}{Application of \LaTeX{} Typesetting in Academic Writing}
-\thesisadvisor{李共济\quad 教授}
-\thesisdate{\the\year}{\the\month}{\the\day} % 使用当前日期; 也可以自定义日期
-
-\MakeCover

--- a/chapters/metadata.tex
+++ b/chapters/metadata.tex
@@ -1,4 +1,18 @@
-% 信息说明页配置
+% ============================================================
+%  封面信息
+% ============================================================
+\school{计算机科学与技术学院}
+\major{计算机科学与技术}
+\student{2654321}{张同舟}
+\thesistitle{\TongjiThesis{} 论文模板使用示例}{\LaTeX{}排版技术在学术写作中的应用}
+\thesistitleeng{\TongjiThesis{} Template Usage Example}{Application of \LaTeX{} Typesetting in Academic Writing}
+\thesisadvisor{李共济\quad 教授}
+\thesisdate{\the\year}{\the\month}{\the\day} % 使用当前日期; 也可以自定义日期
+
+% ============================================================
+%  信息说明页
+% ============================================================
+
 % 成果类型：design（毕业设计）或 thesis（毕业论文）
 \infotype{thesis}
 
@@ -19,5 +33,3 @@
   \item 随附材料名称一（如：全套图纸、程序源代码、计算书等）；
   \item 随附材料名称二
 }
-
-\MakeInfoPage

--- a/main.tex
+++ b/main.tex
@@ -12,9 +12,10 @@
 
 \begin{document}
 
-\input{chapters/frontcover}
+\input{chapters/metadata}
+\MakeCover
 \cleardoublepage
-\input{chapters/infopage}
+\MakeInfoPage
 \cleardoublepage
 
 \frontmatter

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -81,6 +81,10 @@
 % 行距（近似 Word 模板行距倍数；LaTeX 与 Word 的度量略有差异）
 \newcommand{\tjlinespread}{1.625}            % 正文 / 摘要：Word 1.5 倍
 \newcommand{\tjtoclinespread}{1.083}         % 目录：Word 单倍
+% 信息说明页行距（官方规范固定值，linespread = 目标磅数 ÷ (字号 × 1.2)）
+\newcommand{\tjinfofieldspread}{1.6667}   % 四号宋体 28 磅：28÷(14×1.2)≈5/3
+\newcommand{\tjinfoabstractspread}{1.25}  % 摘要小四 18 磅：18÷(12×1.2)=5/4（精确）
+\newcommand{\tjinfotitlevspace}{0.8em}    % 多行课题名称后的间距补偿（在四号上下文中解析）
 % Header and cover text
 \newcommand{\tjheadertext}{毕业设计（论文）}
 
@@ -863,6 +867,8 @@
 \newcommand{\infowordcount}[1]{\def\tongjiinfowordcount{#1}}
 \newcommand{\infothesiswords}[1]{\def\tongjiinfothesiswords{#1}}
 \newcommand{\infomaterials}[1]{\def\tongjiinfomaterials{#1}}
+\newsavebox{\tj@titlebox}
+\newlength{\tj@titledp}
 \newcommand{\infoline}[2]{%
   \noindent #1：#2\par\vspace{0.5em}
 }
@@ -888,13 +894,17 @@
 
     \vspace{1em}
 
-    {\tjfontheading\songti  % 字段标签：四号宋体
+    {\tjfontheading\songti\linespread{\tjinfofieldspread}\selectfont  % 四号宋体，行距 28 磅
     \setlength{\parindent}{0pt}
 
-    \infoline{课题名称}{\parbox[t]{\dimexpr\linewidth-5em\relax}{%
+    \savebox{\tj@titlebox}{\parbox[t]{\dimexpr\linewidth-5em\relax}{%
       \tongjithesistitle
       \ifx\tongjithesissubtitle\empty\else ——\tongjithesissubtitle\fi
     }}%
+    \infoline{课题名称}{\usebox{\tj@titlebox}}%
+    \settodepth{\tj@titledp}{\usebox{\tj@titlebox}}%
+    \addtolength{\tj@titledp}{-\dp\strutbox}%
+    \ifdim\tj@titledp>0pt\vspace{\tjinfotitlevspace}\fi
 
     \infoline{成果类型}{\tjcheckbox{design}\,毕业设计\quad \tjcheckbox{thesis}\,毕业论文}%
 
@@ -903,7 +913,8 @@
     \infoline{内容简述（请用300字以内简要概述）}{%
       \par\vspace{0.2em}
       % 摘要正文用小四号（规范正文字号），外层字段标签为四号
-      {\tjfontbody\setlength{\parindent}{2em}\tongjiinfoabstract\par}
+      {\tjfontbody\linespread{\tjinfoabstractspread}\selectfont% 小四 18 磅
+       \setlength{\parindent}{2em}\tongjiinfoabstract\par}
     }
 
     % 按成果类型只显示对应行（官方模板为二选一）
@@ -914,7 +925,6 @@
     }%
 
     \infoline{随附资料}{%
-      \vspace{0.2em}
       \ifx\tongjiinfomaterials\empty
         \par\vspace{0.5em}
       \else

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -895,7 +895,6 @@
       \tongjithesistitle
       \ifx\tongjithesissubtitle\empty\else ——\tongjithesissubtitle\fi
     }}%
-    \vspace{0.8em}
 
     \infoline{成果类型}{\tjcheckbox{design}\,毕业设计\quad \tjcheckbox{thesis}\,毕业论文}%
 


### PR DESCRIPTION
## 概要 | Summary

修复信息说明页排版问题，对齐官方 Word 模板规范，并整合元数据配置文件。

**原始问题（贡献者发现）：** 单行课题名称后存在多余的 \`\vspace{0.8em}\`，与官方模板不符。

**根本原因：** \`\parbox[t]\` 将外部基线对齐到第一行，多行标题时 parbox 深度远超 \`\baselineskip\`，导致 TeX 将行间距退化为 \`\lineskip = 1pt\`，课题名称与下一字段几乎紧贴——这正是原本加入 \`\vspace{0.8em}\` 的原因。

**修复方案：**
- 用 \`\savebox\` + \`\settodepth\` 测量 parbox 实际深度，仅当标题换行时才插入间距补偿，单行标题不受影响
- 将字段行距和摘要行距对齐官方 Word 模板规范（字段四号宋体 28 磅、摘要小四 18 磅），以 linespread 常量实现，保留 \`\zihao{}\` 语义
- 将 \`chapters/frontcover.tex\` 与 \`chapters/infopage.tex\` 合并为 \`chapters/metadata.tex\`，方便同学集中填写所有论文信息；\`\MakeCover\` 和 \`\MakeInfoPage\` 调用移至 \`main.tex\`

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

## 截图 | Screenshots

去除前：
<img width="645" height="267" alt="Screenshot 2026-04-19 112326" src="https://github.com/user-attachments/assets/59afd381-5151-4462-b575-62c897530aa4" />

去除后：
<img width="661" height="246" alt="Screenshot 2026-04-19 112241" src="https://github.com/user-attachments/assets/a27fb907-8174-4218-8f2f-94d3f5de7051" />

官方word模板：
<img width="945" height="460" alt="image" src="https://github.com/user-attachments/assets/3dc60a63-f1bb-45e4-ad76-5a8508f04226" />