### PR TITLE
fix: correct frontpage font

### DIFF
--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -840,14 +840,14 @@
       \vspace{60pt}
 
       \begin{information}{M{5em}M{22em}}
-        \tjfonttitle\heiti{课题名称} & \ulinecentered{\tongjithesistitle} \\
-        \tjfonttitle\heiti{副\enskip{}标\enskip{}题} & \ulinecentered{\tongjithesissubtitle} \\
-        \tjfonttitle\heiti{学\quad{}\quad{}院} & \ulinecentered{\tongjischool} \\
-        \tjfonttitle\heiti{专\quad{}\quad{}业} & \ulinecentered{\tongjimajor} \\
-        \tjfonttitle\heiti{学生姓名} & \ulinecentered{\tongjiauthor} \\
-        \tjfonttitle\heiti{学\quad{}\quad{}号} & \ulinecentered{\tongjiauthornumber} \\
-        \tjfonttitle\heiti{指导教师} & \ulinecentered{\tongjithesisadvisor} \\
-        \tjfonttitle\heiti{日\quad{}\quad{}期} & \ulinecentered{\tongjithesisyear{}年\tongjithesismonth{}月\tongjithesisday{}日} \\
+        \tjfonttitle\heiti{课题名称} & \ulinecentered{\tjfonttitle\heiti{\tongjithesistitle}} \\
+        \tjfonttitle\heiti{副\enskip{}标\enskip{}题} & \ulinecentered{\tjfonttitle\heiti{\tongjithesissubtitle}} \\
+        \tjfonttitle\heiti{学\quad{}\quad{}院} & \ulinecentered{\tjfonttitle\heiti{\tongjischool}} \\
+        \tjfonttitle\heiti{专\quad{}\quad{}业} & \ulinecentered{\tjfonttitle\heiti{\tongjimajor}} \\
+        \tjfonttitle\heiti{学生姓名} & \ulinecentered{\tjfonttitle\heiti{\tongjiauthor}} \\
+        \tjfonttitle\heiti{学\quad{}\quad{}号} & \ulinecentered{\tjfonttitle\heiti{\tongjiauthornumber}} \\
+        \tjfonttitle\heiti{指导教师} & \ulinecentered{\tjfonttitle\heiti{\tongjithesisadvisor}} \\
+        \tjfonttitle\heiti{日\quad{}\quad{}期} & \ulinecentered{\tjfonttitle\heiti{\tongjithesisyear{}年\tongjithesismonth{}月\tongjithesisday{}日}} \\
       \end{information}
 
       \vfill


### PR DESCRIPTION
## 概要 | Summary

请简要描述本 PR 所做的工作 | Brief description of the changes:

更改封面字体，使得自行填写的内容的字体与其余内容保持一致（和官方模板一致）

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues


## 截图 | Screenshots

修改前：

<img width="667" height="850" alt="Screenshot 2026-04-19 121808" src="https://github.com/user-attachments/assets/36533d84-3033-4947-930a-82c91d840c41" />

修改后：

<img width="632" height="829" alt="Screenshot 2026-04-19 121620" src="https://github.com/user-attachments/assets/3e296e9f-7477-441a-8dd4-b60c3034e04c" />

官方word模板部分示例：
其中，“课题名称”和“论文模板使用示例”的样式是一致的

<img width="742" height="986" alt="Screenshot 2026-04-19 121516" src="https://github.com/user-attachments/assets/8c401dc2-e235-4ad9-9b45-95e450ae759f" />