### PR TITLE
ci: auto-create draft release after test passes on version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,10 +395,10 @@ jobs:
             ctan/tongjithesis/
           retention-days: 90
 
-  # Create GitHub release (only on manual dispatch)
+  # Create GitHub release (on version tag push or manual dispatch)
   release:
     needs: package
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,18 @@ on:
       - "figures/**"
       - ".github/workflows/release.yml"
       - "package.json"
+  workflow_run:
+    workflows: ["test"]
+    types: [completed]
   workflow_dispatch: # Allow manual triggering
 
 jobs:
   # Build CTAN package and source archives (runs on every trigger)
   package:
+    if: |
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -395,10 +402,14 @@ jobs:
             ctan/tongjithesis/
           retention-days: 90
 
-  # Create GitHub release (on version tag push or manual dispatch)
+  # Create GitHub release (after successful test run on a version tag, or manual dispatch)
   release:
     needs: package
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -429,14 +440,18 @@ jobs:
         run: |
           mkdir -p compiled-pdfs
 
-          # Find latest successful test run
-          WORKFLOW_RUN_ID=$(gh run list \
-            --repo "$GITHUB_REPOSITORY" \
-            --workflow="test.yaml" \
-            --status=success \
-            --limit=1 \
-            --json databaseId \
-            --jq '.[0].databaseId' 2>/dev/null || echo "")
+          # Use the exact triggering test run ID when available, otherwise find latest
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            WORKFLOW_RUN_ID="${{ github.event.workflow_run.id }}"
+          else
+            WORKFLOW_RUN_ID=$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow="test.yaml" \
+              --status=success \
+              --limit=1 \
+              --json databaseId \
+              --jq '.[0].databaseId' 2>/dev/null || echo "")
+          fi
 
           if [ -z "$WORKFLOW_RUN_ID" ] || [ "$WORKFLOW_RUN_ID" = "null" ]; then
             echo "No successful test run found. PDFs will not be included."

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,12 +14,18 @@ on:
       - 'LICENSE'
       - '.gitignore'
       - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - '.github/workflows/release.yml'
   pull_request:
     paths-ignore:
       - '*.md'
       - 'LICENSE'
       - '.gitignore'
       - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - '.github/workflows/release.yml'
   workflow_dispatch:
 
 name: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@ on:
       - 'feat/**'
       - 'fix/**'
       - 'refactor/**'
+    tags:
+      - 'v*'
     paths-ignore:
       - '*.md'
       - 'LICENSE'


### PR DESCRIPTION
## 概要 | Summary

推送 `v*` tag 后自动触发完整的发布流程，确保 PDF 编译产物与 tag 对应的提交严格一致：

- `test.yaml` 新增 `tags: v*` 触发条件，tag 推送时运行全平台矩阵编译
- `release.yml` 新增 `workflow_run` 触发器，监听 `test` 工作流完成事件
- `package` 与 `release` 任务仅在 `workflow_run.conclusion == success` 且 `head_branch` 以 `v` 开头时运行，普通分支的 test 完成不会触发发布
- PDF 下载直接使用 `github.event.workflow_run.id`，确保产物来自同一次编译，而非最近一次成功记录
- `workflow_dispatch` 手动触发方式保持不变
- `test.yaml` 的 `paths-ignore` 补充排除 `.github/ISSUE_TEMPLATE/**`、`.github/pull_request_template.md` 与 `.github/workflows/release.yml`，避免与编译无关的文件变更触发耗时的全平台矩阵

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

## 截图 | Screenshots