### PR TITLE
docs: add self-fix checkbox to issue templates and note to PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,3 +34,10 @@ Please upload the `.log` file as an attachment, or paste the key error messages:
 
 如有修改项目文件结构或其他相关信息，请在此补充。
 Any other relevant information, e.g. modified file structure.
+
+## 是否计划自行修复？| Do you plan to fix this yourself?
+
+- [ ] 是，我计划提交 PR 修复此问题 | Yes, I plan to submit a PR to fix this
+
+如勾选，请在提交 PR 时在描述中写明 `Closes #<issue-number>` 以关联本 Issue，方便维护者追踪。
+If checked, please include `Closes #<issue-number>` in your PR description to link it to this issue.

--- a/.github/ISSUE_TEMPLATE/docs_request.md
+++ b/.github/ISSUE_TEMPLATE/docs_request.md
@@ -22,3 +22,10 @@ Describe the documentation content or improvements you expect.
 
 其他与该建议相关的信息。
 Any other relevant information.
+
+## 是否计划自行改进？| Do you plan to improve this yourself?
+
+- [ ] 是，我计划提交 PR 改进文档 | Yes, I plan to submit a PR to improve the documentation
+
+如勾选，请在提交 PR 时在描述中写明 `Closes #<issue-number>` 以关联本 Issue，方便维护者追踪。
+If checked, please include `Closes #<issue-number>` in your PR description to link it to this issue.

--- a/.github/ISSUE_TEMPLATE/feat_request.md
+++ b/.github/ISSUE_TEMPLATE/feat_request.md
@@ -21,3 +21,10 @@ Describe the feature and its importance. Include implementation ideas if any.
 
 其他与该建议相关的信息。
 Any other relevant information.
+
+## 是否计划自行实现？| Do you plan to implement this yourself?
+
+- [ ] 是，我计划提交 PR 实现此功能 | Yes, I plan to submit a PR to implement this
+
+如勾选，请在提交 PR 时在描述中写明 `Closes #<issue-number>` 以关联本 Issue，方便维护者追踪。
+If checked, please include `Closes #<issue-number>` in your PR description to link it to this issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,8 @@
 
 ## 关联 Issue | Related Issues
 
-使用 "Closes #id" 关联相关 Issue，没有则留空。
-Use "Closes #id" to link related issues, or leave empty.
+使用 "Closes #id" 关联相关 Issue，没有则留空。若你在提交本 PR 前已填写对应 Issue 并勾选了"计划自行修复"，请务必在此处关联，合并后 Issue 将自动关闭。
+Use "Closes #id" to link related issues, or leave empty. If you filed an issue first and checked "plan to fix this yourself", link it here — it will be auto-closed on merge.
 
 ## 截图 | Screenshots
 


### PR DESCRIPTION
## 概要 | Summary

- 在三个 Issue 模板（Bug、Feature、Docs）底部新增「是否计划自行修复/实现/改进？」复选框，鼓励贡献者提前声明意图
- 在 PR 模板的「关联 Issue」说明中补充提示：若提 Issue 时已勾选计划自行修复，提 PR 时务必填写 `Closes #<issue-number>`，合并后 Issue 将自动关闭

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

## 截图 | Screenshots