### PR TITLE
chore: add bump-version.sh and tighten CI path exclusions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Extract package metadata
         id: metadata
         run: |
-          VERSION=$(jq -r '.version // "1.3.1"' package.json)
+          VERSION=$(jq -r '.version' package.json)
           AUTHOR=$(jq -r '.author // "TJ-CSCCG"' package.json)
           YEAR=$(date +%Y)
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/pull_request_template.md'
       - '.github/workflows/release.yml'
+      - 'scripts/**'
   pull_request:
     paths-ignore:
       - '*.md'
@@ -26,6 +27,7 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/pull_request_template.md'
       - '.github/workflows/release.yml'
+      - 'scripts/**'
   workflow_dispatch:
 
 name: test

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Bump version across all files and optionally create a git tag.
+#
+# Usage:
+#   ./scripts/bump-version.sh <new-version> [--tag]
+#
+# Examples:
+#   ./scripts/bump-version.sh 1.4.0
+#   ./scripts/bump-version.sh 1.4.0 --tag
+#
+# Updates:
+#   - package.json              "version" field
+#   - style/tongjithesis.cls    \ProvidesClass date and version
+#   - style/tongjithesis.cfg    \ProvidesFile  date and version
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <new-version> [--tag]"
+  echo "Example: $0 1.4.0 --tag"
+  exit 1
+fi
+
+NEW_VERSION="$1"
+CREATE_TAG=false
+if [ "${2:-}" = "--tag" ]; then
+  CREATE_TAG=true
+fi
+
+# Validate semver format
+if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "Error: version must be in X.Y.Z format (got '$NEW_VERSION')"
+  exit 1
+fi
+
+OLD_VERSION=$(jq -r '.version' package.json)
+TODAY=$(date +%Y/%m/%d)
+
+if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+  echo "Error: new version ($NEW_VERSION) is the same as current version"
+  exit 1
+fi
+
+echo "Bumping $OLD_VERSION → $NEW_VERSION (date: $TODAY)"
+
+# package.json
+sed -i.bak "s/\"version\": \"${OLD_VERSION}\"/\"version\": \"${NEW_VERSION}\"/" package.json
+rm package.json.bak
+
+# tongjithesis.cls — update date and version in \ProvidesClass line
+sed -i.bak -E "s/\\\\ProvidesClass\\{tongjithesis\\}\[[0-9/]+ v[0-9]+\.[0-9]+\.[0-9]+/\\\\ProvidesClass{tongjithesis}[${TODAY} v${NEW_VERSION}/" style/tongjithesis.cls
+rm style/tongjithesis.cls.bak
+
+# tongjithesis.cfg — update date and version in \ProvidesFile line
+sed -i.bak -E "s/\\\\ProvidesFile\\{tongjithesis\.cfg\\}\[[0-9/]+ v[0-9]+\.[0-9]+\.[0-9]+/\\\\ProvidesFile{tongjithesis.cfg}[${TODAY} v${NEW_VERSION}/" style/tongjithesis.cfg
+rm style/tongjithesis.cfg.bak
+
+echo ""
+echo "Updated files:"
+grep -n "version\|Provides" package.json style/tongjithesis.cls style/tongjithesis.cfg \
+  | grep -E "version|Provides(Class|File)"
+
+echo ""
+git diff --stat
+
+git add package.json style/tongjithesis.cls style/tongjithesis.cfg
+git commit -m "chore: bump version to v${NEW_VERSION}"
+
+if [ "$CREATE_TAG" = true ]; then
+  git tag "v${NEW_VERSION}"
+  echo ""
+  echo "Tagged v${NEW_VERSION}. Push with:"
+  echo "  git push && git push origin v${NEW_VERSION}"
+else
+  echo ""
+  echo "Done. To also create a tag, run:"
+  echo "  git tag v${NEW_VERSION}"
+  echo "  git push && git push origin v${NEW_VERSION}"
+fi


### PR DESCRIPTION
## 概要 | Summary

- 新增 `scripts/bump-version.sh`：一条命令同步更新 `package.json`、`tongjithesis.cls`、`tongjithesis.cfg` 中的版本号与日期，`--tag` 参数可同时创建 git tag
- `release.yml`：移除 `jq` 版本号硬编码回退值 `// "1.3.1"`，`package.json` 解析失败时直接报错，避免静默生成错误版本号的发布产物
- `test.yaml`：`paths-ignore` 补充排除 `scripts/**`，脚本变更不再触发耗时的全平台编译矩阵

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

## 截图 | Screenshots