### PR TITLE
fix: widen heading aftername gap with \hspace{0.5em}

### DIFF
--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -471,8 +471,8 @@
   \counterwithin{algorithm}{section}%
   \counterwithin{listing}{section}%
   \counterwithin{lstlisting}{section}%
-  % 标题格式 "A. 节名"（点号 + 空格）
-  \ctexset{section/aftername={.\space}}%
+  % 标题格式 "A. 节名"（点号 + 0.5em 空格，与正文二级及以下标题一致）
+  \ctexset{section/aftername={.\hspace{0.5em}}}%
 }
 \newcommand{\appendixsection}{\section}
 \newcommand{\appendixsubsection}{\subsection}
@@ -597,13 +597,13 @@
   },
   section={%
     format={\heiti\tjfontbody},
-    aftername={\space},
+    aftername={\hspace{0.5em}},
     beforeskip={\tjskipbeforesec},
     afterskip={\tjskipaftersec},
   },
   subsection={%
     format={\heiti\tjfontbody},
-    aftername={\space},
+    aftername={\hspace{0.5em}},
     beforeskip={\tjskipbeforesec},
     afterskip={\tjskipaftersec},
     indent={2em},
@@ -612,7 +612,7 @@
     format={\heiti\tjfontbody},
     numbering=true,
     number={\Alph{subsubsection}},
-    aftername={.\space},
+    aftername={.\hspace{0.5em}},
     beforeskip={0pt},
     afterskip={0pt},
     indent={2em},
@@ -622,7 +622,7 @@
     format={\heiti\tjfontbody},
     numbering=true,
     number={\alph{paragraph}},
-    aftername={.\space},
+    aftername={.\hspace{0.5em}},
     beforeskip={0pt},
     afterskip={0pt},
     indent={2em},


### PR DESCRIPTION
## 概要 | Summary

请简要描述本 PR 所做的工作 | Brief description of the changes:

- 将 `style/tongjithesis.cls` 中各级标题（`section` / `subsection` / `subsubsection` / `paragraph`）以及附录 `section` 的 `aftername` 键由 `\space` 改为 `\hspace{0.5em}`，使序号后的空白宽度更接近官方 Word 模板的中文空格观感，并避免行末折叠。
- Replace `\space` with `\hspace{0.5em}` in the `aftername` keys of `section` / `subsection` / `subsubsection` / `paragraph` and the appendix `section` override in `style/tongjithesis.cls`, giving a stable 0.5em gap that matches the official Word template and will not collapse at line breaks.

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

Closes #86

## 截图 | Screenshots

此改动仅影响标题序号与文字之间的水平间距，效果需在编译后的 PDF 中目视比对。CI 的 `test.yaml` 工作流会自动编译所有样例文档，可据此核对渲染结果。
This change only affects the horizontal gap between heading numbers and titles; visual inspection of the compiled PDF is recommended. CI (`test.yaml`) compiles the sample documents and can be used to verify the rendered output.