### PR TITLE
fix: use 设计总说明 as Chinese abstract heading for 毕业设计

### DIFF
--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -938,7 +938,7 @@
   \global\tjbindinglinetrue
 }
 
-% 设置中文摘要页
+% 设置中文摘要页（毕业设计时标题改为"设计总说明"）
 \newcommand{\MakeAbstract}[2]{
   \begin{center}\bfseries\heiti\tjfonttitle
     \ \\
@@ -950,7 +950,7 @@
   \end{center}
   \vspace{-0.8em}
   \begin{center}\heiti\tjfontheading
-    摘\hspace{0.5em}要
+    \ifthenelse{\equal{\tongjiinfotype}{design}}{设计总说明}{摘\hspace{0.5em}要}
   \end{center}
 
   \begin{spacing}{\tjlinespread}


### PR DESCRIPTION
## 概要 | Summary

- 当 `\infotype{design}` 时，`\MakeAbstract` 将中文摘要标题从「摘要」改为「设计总说明」
- 英文摘要标题「ABSTRACT」不受影响

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

## 截图 | Screenshots

如涉及模板输出变化，请附上编译产物截图，没有则删除本节。
If the template output changes, attach compiled PDF screenshots. Otherwise delete this section.