### PR TITLE
fix: 统一Header为"毕业设计（论文）"，移除 humanities 条件判断

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,7 +1,7 @@
 \documentclass[
   oneside,
   degree=bachelor,
-  field=science,
+  field=humanities,
   fullwidthstop=circle,
   fontset=fandol,
   times=false,

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -101,12 +101,8 @@
 \newcommand{\tjinfotitlevspace}{0.8em}    % 多行课题名称后的间距补偿（在四号上下文中解析）
 % Cover text：封面大标题恒定为"毕业设计（论文）"（文理科一致）
 \newcommand{\tjcovertext}{毕业设计（论文）}
-% Header text：理工=毕业设计（论文）；文科=毕业论文（设计）
-\iftongjithesis@humanities
-  \newcommand{\tjheadertext}{毕业论文（设计）}
-\else
-  \newcommand{\tjheadertext}{毕业设计（论文）}
-\fi
+% Header text
+\newcommand{\tjheadertext}{毕业设计（论文）}
 
 % ==========================================
 % Required Packages


### PR DESCRIPTION
## Summary

- 移除 `tongjithesis.cls` 中 `tjheadertext` 的 `humanities` 条件判断
- 统一 Header 显示为"毕业设计（论文）"，工科和文科版本保持一致

## Changes

- `style/tongjithesis.cls`：删去 `\iftongjithesis@humanities` 条件分支，直接设置 `\tjheadertext` 为"毕业设计（论文）"

## Test plan

- [x] 本地编译通过
- [x] 确认 Header 显示正确
