### PR TITLE
feat: 对齐 2026 撰写规范（field 标题文本、目录字号、页边距注释）

### DIFF
--- a/chapters/02_intro.tex
+++ b/chapters/02_intro.tex
@@ -96,10 +96,10 @@
     \textbf{字号命令} & \textbf{字号名称} & \textbf{用途} \\
     \midrule
     \texttt{\textbackslash zihao\{-2\}} & 小二号 & 课题名称、摘要页标题 \\
-    \texttt{\textbackslash zihao\{-3\}} & 小三号 & 章标题、目录标题、封面字段值 \\
+    \texttt{\textbackslash zihao\{-3\}} & 小三号 & 章标题、封面字段值 \\
     \texttt{\textbackslash zihao\{3\}}  & 三号   & 摘要副标题（\texttt{\textbackslash tjfontinfotitle}：信息说明页标题） \\
-    \texttt{\textbackslash zihao\{4\}}  & 四号   & 摘要/参考文献/谢辞标题 \\
-    \texttt{\textbackslash zihao\{-4\}} & 小四号 & 正文、节标题、页眉页脚 \\
+    \texttt{\textbackslash zihao\{4\}}  & 四号   & 摘要、目录、参考文献、谢辞标题 \\
+    \texttt{\textbackslash zihao\{-4\}} & 小四号 & 正文、节标题、页眉页脚、目录内容、公式 \\
     \texttt{\textbackslash zihao\{5\}}  & 五号   & 脚注、装订线文字 \\
     \texttt{\textbackslash zihao\{-5\}} & 小五号 & 表题、图题、表内文字 \\
     \bottomrule

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -118,7 +118,7 @@
 % Page layout
 % headheight 43pt ≈ 1.14cm logo (≈32pt) + 小四号正文行 (≈11pt)；防止 fancyhdr headheight warning
 \setlength{\headheight}{43pt}
-% 页边距按同济本科毕业设计（论文）官方 Word 模板复刻
+% 页边距按同济本科毕业设计（论文）/毕业论文（设计）官方 Word 模板复刻
 \RequirePackage[a4paper,top=4.0cm,bottom=2.7cm,left=3.3cm,right=1.8cm]{geometry}
 \RequirePackage{fancyhdr}
 \RequirePackage{lastpage}

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -99,8 +99,12 @@
 \newcommand{\tjinfofieldspread}{1.6667}   % 四号宋体 28 磅：28÷(14×1.2)≈5/3
 \newcommand{\tjinfoabstractspread}{1.25}  % 摘要小四 18 磅：18÷(12×1.2)=5/4（精确）
 \newcommand{\tjinfotitlevspace}{0.8em}    % 多行课题名称后的间距补偿（在四号上下文中解析）
-% Cover text：封面大标题恒定为"毕业设计（论文）"（文理科一致）
-\newcommand{\tjcovertext}{毕业设计（论文）}
+% Cover text：理工=毕业设计（论文）；文科=毕业论文（设计）
+\iftongjithesis@humanities
+  \newcommand{\tjcovertext}{毕业论文（设计）}
+\else
+  \newcommand{\tjcovertext}{毕业设计（论文）}
+\fi
 % Header text：理工=毕业设计（论文）；文科=毕业论文（设计）
 \iftongjithesis@humanities
   \newcommand{\tjheadertext}{毕业论文（设计）}
@@ -936,7 +940,7 @@
       \tjfonttitle\MakeUppercase{\textbf{\tongjiuniversityeng}}
       % \vskip 20pt
 
-      % 封面「毕业设计（论文）」字样：初号黑体（官方模板规范，文理科一致）
+      % 封面大标题：初号黑体（官方模板规范，理工/文科不同）
       \zihao{-0}\heiti{\tjcovertext}
       \vspace{60pt}
 
@@ -988,7 +992,7 @@
     \pagestyle{empty}% 防止信息页溢出到第二页时出现页码（titlepage 只 \thispagestyle empty）
 
     \begin{center}
-      \tjfontinfotitle\heiti 同济大学本科毕业设计（论文）信息说明页
+      \tjfontinfotitle\heiti 同济大学本科\tjheadertext 信息说明页
     \end{center}
 
     \vspace{1em}

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -80,8 +80,8 @@
 % ==========================================
 % Font sizes
 \newcommand{\tjfonttitle}{\zihao{-2}}        % 课题名称：小二号
-\newcommand{\tjfontchapter}{\zihao{-3}}      % 章标题 / 目录标题：小三号
-\newcommand{\tjfontheading}{\zihao{4}}       % 摘要标题 / 参考文献 / 谢辞标题：四号
+\newcommand{\tjfontchapter}{\zihao{-3}}      % 章标题：小三号
+\newcommand{\tjfontheading}{\zihao{4}}       % 摘要 / 目录 / 参考文献 / 谢辞标题：四号
 \newcommand{\tjfontbody}{\zihao{-4}}         % 正文 / 二三级标题 / 关键词 / 摘要正文：小四号
 \newcommand{\tjfontcaption}{\zihao{-5}}      % 表题 / 图题：小五号
 \newcommand{\tjfontcover}{\zihao{-3}}        % 封面表格字段值：小三号（与 \tjfontchapter 同字号，语义分离）
@@ -564,7 +564,7 @@
 \setlength{\cftbeforesecskip}{0pt}
 \setlength{\cftbeforesubsecskip}{0pt}
 \renewcommand{\contentsname}{目\hspace{0.5em}录}
-\renewcommand{\cfttoctitlefont}{\hfill\heiti\tjfontchapter}
+\renewcommand{\cfttoctitlefont}{\hfill\heiti\tjfontheading}
 \renewcommand{\cftaftertoctitle}{\hfill}
 % 目录标题后留一空行（匹配官方 Word 模板）
 % tocloft[titles] 下 \cftaftertoctitleskip 无效——\tableofcontents 内部走 \chapter*，


### PR DESCRIPTION
## 概要 | Summary

- 封面大标题、信息说明页标题根据 `field` 选项条件输出：
  - `field=science`（理工科）：毕业设计（论文）
  - `field=humanities`（文科）：毕业论文（设计）
- 页边距注释补充两种版本说明
- 目录标题字号对齐撰写规范：小三号 → 四号

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

## Changes

- `style/tongjithesis.cls`：
  - 信息说明页标题改为引用 `\tjheadertext` 变量，并更新相关注释
  - 页边距注释补充两种版本说明
  - `\cfttoctitlefont` 由 `\tjfontchapter`（小三号）改为 `\tjfontheading`（四号），目录标题对齐撰写规范"目录为四号黑体居中"
  - 注释微调：`\tjfontchapter` 收窄为仅章标题；`\tjfontheading` 补充目录标题
- `chapters/02_intro.tex`：常用字号对照表与实现/规范对齐
  - 小三号：移除"目录标题"
  - 四号：增加"目录"
  - 小四号：补全"目录内容、公式"

## Test plan

- [x] 本地编译通过（`field=science`）
- [x] 本地编译通过（`field=humanities`）
- [x] 目录页 "目 录" 标题渲染为四号黑体