### PR TITLE
fix: replace ProvidesExplFile with ProvidesFile to preserve spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TongjiThesis",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "LaTeX template for Tongji University undergraduate thesis",
   "author": "TJ-CSCCG",
   "email": "TJ_CSCCG@163.com",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -12,7 +12,7 @@
 #   - package.json              "version" field
 #   - style/tongjithesis.cls    \ProvidesClass date and version
 #   - style/tongjithesis.cfg    \ProvidesFile  date and version
-#   - style/font/*.def          \ProvidesExplFile date and version
+#   - style/font/*.def          \ProvidesFile  date and version
 
 set -euo pipefail
 
@@ -56,9 +56,9 @@ rm style/tongjithesis.cls.bak
 sed -i.bak -E 's#(\\ProvidesFile\{tongjithesis\.cfg\}\[)[0-9][0-9/]* v[0-9]+\.[0-9]+\.[0-9]+#\1'"${TODAY} v${NEW_VERSION}#" style/tongjithesis.cfg
 rm style/tongjithesis.cfg.bak
 
-# style/font/*.def — update date and version in \ProvidesExplFile lines
+# style/font/*.def — update date and version in \ProvidesFile lines
 for def in style/font/tongji-cjk-font-*.def; do
-  sed -i.bak -E 's#  \{[0-9][0-9/]*\}\{[0-9]+\.[0-9]+\.[0-9]+\}#  \{'"${TODAY}"'\}\{'"${NEW_VERSION}"'\}#' "$def"
+  sed -i.bak -E 's#(\\ProvidesFile\{[^}]+\}\[)[0-9][0-9/]* v[0-9]+\.[0-9]+\.[0-9]+#\1'"${TODAY} v${NEW_VERSION}#" "$def"
   rm "${def}.bak"
 done
 

--- a/style/font/tongji-cjk-font-adobe.def
+++ b/style/font/tongji-cjk-font-adobe.def
@@ -4,7 +4,7 @@
 %% Copyright (C) TJ-CSCCG
 %% This work may be distributed under the LPPL 1.3c or later.
 %%
-\ProvidesFile{tongji-cjk-font-adobe.def}[2026/05/02 v1.4.0 Adobe CJK fonts definition (TongjiThesis)]
+\ProvidesFile{tongji-cjk-font-adobe.def}[2026/05/03 v1.4.1 Adobe CJK fonts definition (TongjiThesis)]
 
 \setCJKmainfont{AdobeSongStd-Light}
   [ BoldFont = AdobeHeitiStd-Regular, ItalicFont = AdobeKaitiStd-Regular ]

--- a/style/font/tongji-cjk-font-adobe.def
+++ b/style/font/tongji-cjk-font-adobe.def
@@ -4,8 +4,7 @@
 %% Copyright (C) TJ-CSCCG
 %% This work may be distributed under the LPPL 1.3c or later.
 %%
-\ProvidesExplFile{tongji-cjk-font-adobe.def}
-  {2026/05/02}{1.4.0}{Adobe CJK fonts definition (TongjiThesis)}
+\ProvidesFile{tongji-cjk-font-adobe.def}[2026/05/02 v1.4.0 Adobe CJK fonts definition (TongjiThesis)]
 
 \setCJKmainfont{AdobeSongStd-Light}
   [ BoldFont = AdobeHeitiStd-Regular, ItalicFont = AdobeKaitiStd-Regular ]

--- a/style/font/tongji-cjk-font-fandol.def
+++ b/style/font/tongji-cjk-font-fandol.def
@@ -4,7 +4,7 @@
 %% Copyright (C) TJ-CSCCG
 %% This work may be distributed under the LPPL 1.3c or later.
 %%
-\ProvidesFile{tongji-cjk-font-fandol.def}[2026/05/02 v1.4.0 Fandol CJK fonts definition (TongjiThesis)]
+\ProvidesFile{tongji-cjk-font-fandol.def}[2026/05/03 v1.4.1 Fandol CJK fonts definition (TongjiThesis)]
 
 \setCJKmainfont{FandolSong}
   [

--- a/style/font/tongji-cjk-font-fandol.def
+++ b/style/font/tongji-cjk-font-fandol.def
@@ -4,8 +4,7 @@
 %% Copyright (C) TJ-CSCCG
 %% This work may be distributed under the LPPL 1.3c or later.
 %%
-\ProvidesExplFile{tongji-cjk-font-fandol.def}
-  {2026/05/02}{1.4.0}{Fandol CJK fonts definition (TongjiThesis)}
+\ProvidesFile{tongji-cjk-font-fandol.def}[2026/05/02 v1.4.0 Fandol CJK fonts definition (TongjiThesis)]
 
 \setCJKmainfont{FandolSong}
   [

--- a/style/font/tongji-cjk-font-founder.def
+++ b/style/font/tongji-cjk-font-founder.def
@@ -4,8 +4,7 @@
 %% Copyright (C) TJ-CSCCG
 %% This work may be distributed under the LPPL 1.3c or later.
 %%
-\ProvidesExplFile{tongji-cjk-font-founder.def}
-  {2026/05/02}{1.4.0}{Founder CJK fonts definition (TongjiThesis)}
+\ProvidesFile{tongji-cjk-font-founder.def}[2026/05/02 v1.4.0 Founder CJK fonts definition (TongjiThesis)]
 
 \setCJKmainfont{FZShuSong-Z01}
   [ BoldFont = FZXiaoBiaoSong-B05, ItalicFont = FZKai-Z03 ]

--- a/style/font/tongji-cjk-font-founder.def
+++ b/style/font/tongji-cjk-font-founder.def
@@ -4,7 +4,7 @@
 %% Copyright (C) TJ-CSCCG
 %% This work may be distributed under the LPPL 1.3c or later.
 %%
-\ProvidesFile{tongji-cjk-font-founder.def}[2026/05/02 v1.4.0 Founder CJK fonts definition (TongjiThesis)]
+\ProvidesFile{tongji-cjk-font-founder.def}[2026/05/03 v1.4.1 Founder CJK fonts definition (TongjiThesis)]
 
 \setCJKmainfont{FZShuSong-Z01}
   [ BoldFont = FZXiaoBiaoSong-B05, ItalicFont = FZKai-Z03 ]

--- a/style/font/tongji-cjk-font-windows.def
+++ b/style/font/tongji-cjk-font-windows.def
@@ -4,7 +4,7 @@
 %% Copyright (C) TJ-CSCCG
 %% This work may be distributed under the LPPL 1.3c or later.
 %%
-\ProvidesFile{tongji-cjk-font-windows.def}[2026/05/02 v1.4.0 Windows CJK fonts definition (TongjiThesis)]
+\ProvidesFile{tongji-cjk-font-windows.def}[2026/05/03 v1.4.1 Windows CJK fonts definition (TongjiThesis)]
 
 \setCJKmainfont{SimSun}
   [ BoldFont = SimHei, ItalicFont = KaiTi ]

--- a/style/font/tongji-cjk-font-windows.def
+++ b/style/font/tongji-cjk-font-windows.def
@@ -4,8 +4,7 @@
 %% Copyright (C) TJ-CSCCG
 %% This work may be distributed under the LPPL 1.3c or later.
 %%
-\ProvidesExplFile{tongji-cjk-font-windows.def}
-  {2026/05/02}{1.4.0}{Windows CJK fonts definition (TongjiThesis)}
+\ProvidesFile{tongji-cjk-font-windows.def}[2026/05/02 v1.4.0 Windows CJK fonts definition (TongjiThesis)]
 
 \setCJKmainfont{SimSun}
   [ BoldFont = SimHei, ItalicFont = KaiTi ]

--- a/style/tongjithesis.cfg
+++ b/style/tongjithesis.cfg
@@ -1,7 +1,7 @@
 \ProvidesFile{tongjithesis.cfg}[2026/05/02 v1.4.0 Tongji University Thesis Class configuration file]
 
 \def\tongjiuniversity{同济大学}
-\def\tongjiuniversityeng{Tongji\ University}
+\def\tongjiuniversityeng{Tongji University}
 \def\tongjischool{}
 \def\tongjimajor{}
 \def\tongjiauthornumber{}

--- a/style/tongjithesis.cfg
+++ b/style/tongjithesis.cfg
@@ -1,4 +1,4 @@
-\ProvidesFile{tongjithesis.cfg}[2026/05/02 v1.4.0 Tongji University Thesis Class configuration file]
+\ProvidesFile{tongjithesis.cfg}[2026/05/03 v1.4.1 Tongji University Thesis Class configuration file]
 
 \def\tongjiuniversity{同济大学}
 \def\tongjiuniversityeng{Tongji University}

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -2,7 +2,7 @@
 % tongjithesis -- Tongji University Thesis Template
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{tongjithesis}[2026/05/02 v1.4.0 Tongji University Thesis Class]
+\ProvidesClass{tongjithesis}[2026/05/03 v1.4.1 Tongji University Thesis Class]
 
 %% TongjiThesis
 %% Copyright 2023-2026 TJ-CSCCG


### PR DESCRIPTION
## 概要 | Summary

将 CJK 字体定义文件中的 `\ProvidesExplFile` 替换为 `\ProvidesFile`（LaTeX2e 标准格式），修复因 LaTeX3 语法模式导致的空格丢失问题。

Replace `\ProvidesExplFile` with `\ProvidesFile` (standard LaTeX2e format) in CJK fontset definition files to fix space loss caused by LaTeX3 syntax mode.

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

Closes #97

## 截图 | Screenshots

修复前：`Keywords:font; test`（空格丢失）
修复后：`Key words: font; test`（空格正常）