### PR TITLE
Feat/fix subcaption font

### DIFF
--- a/chapters/02_intro.tex
+++ b/chapters/02_intro.tex
@@ -100,8 +100,8 @@
     \texttt{\textbackslash zihao\{3\}}  & 三号   & 摘要副标题（\texttt{\textbackslash tjfontinfotitle}：信息说明页标题） \\
     \texttt{\textbackslash zihao\{4\}}  & 四号   & 摘要、目录、参考文献、谢辞标题 \\
     \texttt{\textbackslash zihao\{-4\}} & 小四号 & 正文、节标题、页眉页脚、目录内容、公式 \\
-    \texttt{\textbackslash zihao\{5\}}  & 五号   & 脚注、装订线文字 \\
-    \texttt{\textbackslash zihao\{-5\}} & 小五号 & 表题、图题、表内文字 \\
+    \texttt{\textbackslash zihao\{5\}}  & 五号   & 表题、图题、装订线文字 \\
+    \texttt{\textbackslash zihao\{-5\}} & 小五号 & 表内文字 \\
     \bottomrule
   \end{tabular}
 \end{table}

--- a/chapters/03_float.tex
+++ b/chapters/03_float.tex
@@ -58,7 +58,7 @@
   \end{minipage}
 \end{figure}
 
-若希望多个子图共用一个计数器并分别拥有子图题，使用 \pkg{subcaption} 宏包的 \cs{subcaptionbox} 命令（或 \texttt{subfigure} 环境），子图号以 a)、b) 区分，如\cref{fig:subcaptionbox}。
+若希望多个子图共用一个计数器并分别拥有子图题，使用 \pkg{subcaption} 宏包的 \cs{subcaptionbox} 命令（或 \texttt{subfigure} 环境），子图号以 (a)、(b) 区分，如\cref{fig:subcaptionbox}。
 
 \begin{figure}[!htb]
   \centering

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -181,6 +181,7 @@
 \captionsetup[listing]{skip=12pt}
 
 \RequirePackage{subcaption}
+\captionsetup[sub]{font={tj@caption,tj@songti},labelformat=simple,labelsep=space,skip=6pt}
 
 % Algorithms and code listings
 \RequirePackage{algorithm}

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -90,7 +90,7 @@
 \newcommand{\tjfontchapter}{\zihao{-3}}      % 章标题：小三号
 \newcommand{\tjfontheading}{\zihao{4}}       % 摘要 / 目录 / 参考文献 / 谢辞标题：四号
 \newcommand{\tjfontbody}{\zihao{-4}}         % 正文 / 二三级标题 / 关键词 / 摘要正文：小四号
-\newcommand{\tjfontcaption}{\zihao{-5}}      % 表题 / 图题：小五号
+\newcommand{\tjfontcaption}{\zihao{5}}      % 表题 / 图题：五号
 \newcommand{\tjfontcover}{\zihao{-3}}        % 封面表格字段值：小三号（与 \tjfontchapter 同字号，语义分离）
 \newcommand{\tjfonttable}{\zihao{-5}}        % 表内文字：小五号
 \newcommand{\tjfontinfotitle}{\zihao{3}}     % 信息说明页标题：三号（仅此页专用）

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -90,7 +90,7 @@
 \newcommand{\tjfontchapter}{\zihao{-3}}      % 章标题：小三号
 \newcommand{\tjfontheading}{\zihao{4}}       % 摘要 / 目录 / 参考文献 / 谢辞标题：四号
 \newcommand{\tjfontbody}{\zihao{-4}}         % 正文 / 二三级标题 / 关键词 / 摘要正文：小四号
-\newcommand{\tjfontcaption}{\zihao{5}}      % 表题 / 图题：五号
+\newcommand{\tjfontcaption}{\zihao{5}}       % 表题 / 图题：五号
 \newcommand{\tjfontcover}{\zihao{-3}}        % 封面表格字段值：小三号（与 \tjfontchapter 同字号，语义分离）
 \newcommand{\tjfonttable}{\zihao{-5}}        % 表内文字：小五号
 \newcommand{\tjfontinfotitle}{\zihao{3}}     % 信息说明页标题：三号（仅此页专用）
@@ -181,7 +181,10 @@
 \captionsetup[listing]{skip=12pt}
 
 \RequirePackage{subcaption}
-\captionsetup[sub]{font={tj@caption,tj@songti},labelformat=simple,labelsep=space,skip=6pt}
+% Override subcaption default `font+=smaller` so sub-captions match main caption size.
+% Other settings (labelsep, labelformat, skip) inherit defaults — labelsep follows the
+% global tj@twospace from line above; labelformat=parens renders `(a)` style.
+\captionsetup[sub]{font={tj@caption,tj@songti}}
 
 % Algorithms and code listings
 \RequirePackage{algorithm}


### PR DESCRIPTION
## 修复方案（已实现）

将 caption 字号从小五号 \zihao{-5} 改为五号 \zihao{5}，主图题和子图题现在均为五号。
该修复已推送到分支 feat/fix-subcaption-font，经 PDF 编译验证，子图题字体大小恢复为与主图题一致。

Closes #101