### PR TITLE
fix: align bibliography labels to page margin with 0.74cm hanging indent

### DIFF
--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -309,10 +309,36 @@
     style=gb7714-2015,
     natbib=true,
   ]{biblatex}
+  % 参考文献序号左对齐至页边距，悬挂统一为 0.74cm（与 Word 模板一致）。
+  % 0.74cm 为最小宽度；若实际最宽标签（如 [100]+ 三位数引用）超过 0.74cm，
+  % 则使用实际宽度，避免标签溢出与正文首字符重叠。
+  \defbibenvironment{bibliography}
+    {\list
+       {\printtext[labelnumberwidth]{%
+          \printfield{labelprefix}%
+          \printfield{labelnumber}}}
+       {\setlength{\labelwidth}{\labelnumberwidth}%
+        \ifdim\labelwidth<0.74cm \setlength{\labelwidth}{0.74cm}\fi
+        \setlength{\labelsep}{0pt}%
+        \setlength{\leftmargin}{\labelwidth}%
+        \setlength{\itemindent}{0pt}%
+        \setlength{\itemsep}{\bibitemsep}%
+        \setlength{\parsep}{\bibparsep}%
+        \renewcommand*{\makelabel}[1]{##1\hfill}}}
+    {\endlist}
+    {\item}
 \else
   \RequirePackage[sort&compress]{gbt7714}
   \bibliographystyle{gbt7714-numerical}
   \setlength{\bibsep}{3pt}
+  % 参考文献序号左对齐至页边距，悬挂统一为 0.74cm（与 Word 模板一致）。
+  % gbt7714 已将 \@biblabel 改为 [#1]\hfill（左对齐），此处只需固定标签框宽度。
+  % 0.74cm 为最小宽度；若 thebibliography 自动测量的最宽标签更宽，则保留之，
+  % 避免 [100]+ 三位数引用时标签溢出与正文首字符重叠。
+  \renewcommand{\@openbib@code}{%
+    \ifdim\labelwidth<0.74cm \setlength{\labelwidth}{0.74cm}\fi
+    \setlength{\labelsep}{0pt}%
+    \setlength{\leftmargin}{\labelwidth}}
 \fi
 
 % \tjbibresource{file1,file2,...} — register bib files (preamble only)

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -332,13 +332,20 @@
   \bibliographystyle{gbt7714-numerical}
   \setlength{\bibsep}{3pt}
   % 参考文献序号左对齐至页边距，悬挂统一为 0.74cm（与 Word 模板一致）。
-  % gbt7714 已将 \@biblabel 改为 [#1]\hfill（左对齐），此处只需固定标签框宽度。
-  % 0.74cm 为最小宽度；若 thebibliography 自动测量的最宽标签更宽，则保留之，
-  % 避免 [100]+ 三位数引用时标签溢出与正文首字符重叠。
-  \renewcommand{\@openbib@code}{%
+  % gbt7714 已将 \@biblabel 改为 [#1]\hfill（左对齐）。natbib（gbt7714 内部加载）
+  % 重写了 thebibliography，绕过 book.cls 的 \@openbib@code 钩子，因此须直接
+  % 替换 numeric 模式下的列表参数宏 \@bibsetup（natbib 默认 \let 至 \NAT@bibsetnum）。
+  % 0.74cm 为最小宽度；若实际最宽标签更宽（如 [100]+），则使用实际宽度。
+  % \AtBeginDocument 确保替换在 natbib 自身 \NAT@set@cites 钩子（同样在 \AtBeginDocument）
+  % 之后生效；用独立辅助宏 \tj@bibsetup 避免 \xdef 展开期 ## 参数歧义。
+  \newcommand{\tj@bibsetup}[1]{%
+    \settowidth\labelwidth{\@biblabel{#1}}%
     \ifdim\labelwidth<0.74cm \setlength{\labelwidth}{0.74cm}\fi
+    \setlength{\leftmargin}{\labelwidth}%
     \setlength{\labelsep}{0pt}%
-    \setlength{\leftmargin}{\labelwidth}}
+    \setlength{\itemsep}{\bibsep}%
+    \setlength{\parsep}{\z@}}
+  \AtBeginDocument{\let\@bibsetup\tj@bibsetup}
 \fi
 
 % \tjbibresource{file1,file2,...} — register bib files (preamble only)


### PR DESCRIPTION
## 概要 | Summary

请简要描述本 PR 所做的工作 | Brief description of the changes:

- 将参考文献列表的序号 `[N]` 由原来的"右对齐到 `]`"（biblatex `gb7714-2015` 默认行为）改为"左对齐到页边距"，并将悬挂缩进统一为 0.74cm，与 Word 模板一致。
- 同时覆盖 biblatex（`gb7714-2015`）与 bibtex（`gbt7714` 内部加载 `natbib`）两条路径。
- 标签宽度按 `max(0.74cm, 自动测量值)` 取较大者，避免 `[100]+` 三位数引用时序号与正文首字符重叠。

实现细节 | Implementation:

- **biblatex 路径**：用 `\defbibenvironment{bibliography}{...}` 重写参考文献列表的 `\list` 环境，固定 `\labelwidth` / `\leftmargin` 至 0.74cm（不足则取 `\labelnumberwidth`），`\labelsep=0pt`，并通过 `\renewcommand*{\makelabel}[1]{##1\hfill}` 让标签在框内左对齐。
- **bibtex 路径**：`gbt7714` 已将 `\@biblabel` 重定义为 `[#1]\hfill`（标签左对齐于其框内）。`gbt7714` 内部加载 `natbib`，后者重写了 `thebibliography` 并绕过 `book.cls` 的 `\@openbib@code` 钩子，因此须直接替换 numeric 模式下的列表参数宏 `\@bibsetup`（natbib 在 `\AtBeginDocument` 中将其 `\let` 至 `\NAT@bibsetnum`）。本 PR 在 cls 中定义独立辅助宏 `\tj@bibsetup`，并以 `\AtBeginDocument{\let\@bibsetup\tj@bibsetup}` 在 natbib 自身钩子之后接管参数设置（独立宏避免 `\xdef` 展开期 `##` 参数歧义）。

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

注：两条路径均已在 macOS + TeX Live 2026 上以 `bib/note.bib`（共 21 条引用）编译验证。两种模式下 `[1]`–`[9]` 标签 `\hfill` 后仍剩可见空隙，`[10]`–`[21]` 标签恰好填满 0.74cm 标签框（与 Word 模板视觉一致），悬挂缩进统一为 0.74cm。

## 关联 Issue | Related Issues

Closes #104 

## 截图 | Screenshots

修复前 | Before — biblatex `gb7714-2015` 默认行为，`]` 对齐：

```
 [8]  FIELDING R T, RESCHKE J F. Hypertext...
 [9]  LI M. Scaling Distributed Machine...
[10]  CHEN L. Better Hardness via Algorithms...
```

修复后 | After — 序号左对齐至页边距，悬挂 0.74cm（biblatex 与 bibtex 两路径行为一致）：

```
[8] FIELDING R T, RESCHKE J F. Hypertext...
[9] LI M. Scaling Distributed Machine...
[10]CHEN L. Better Hardness via Algorithms...
[11]ZHANG W. Optimal Real-Time Bidding...
```

（与 Word 模板视觉一致：标签 `[N]` 顶头排版，悬挂缩进为 0.74cm。当 `[N]` 自然宽度等于或超过 0.74cm 时，`]` 与正文首字符之间无可见空隙，与 Word 行为一致。）