### PR TITLE
refactor: optimize CI matrix and release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,15 +459,14 @@ jobs:
           fi
 
           echo "Downloading release PDFs from test run: $WORKFLOW_RUN_ID"
-          if gh run download "$WORKFLOW_RUN_ID" \
+          for field in science humanities; do
+            gh run download "$WORKFLOW_RUN_ID" \
               --repo "$GITHUB_REPOSITORY" \
-              --name release-pdfs \
-              --dir release-pdfs 2>/dev/null; then
-            echo "Downloaded PDFs:"
-            ls -la release-pdfs/*.pdf
-          else
-            echo "Could not download release PDFs. Continuing without them."
-          fi
+              --name "release-pdf-${field}" \
+              --dir release-pdfs 2>/dev/null || true
+          done
+          echo "Downloaded PDFs:"
+          ls -la release-pdfs/*.pdf 2>/dev/null || echo "No release PDFs found"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,12 +435,11 @@ jobs:
         with:
           name: release-packages-v${{ env.PACKAGE_VERSION }}
 
-      - name: Download compiled PDFs from test workflow
+      - name: Download release PDFs from test workflow
         if: steps.check.outputs.exists == 'false'
         run: |
-          mkdir -p compiled-pdfs
+          mkdir -p release-pdfs
 
-          # Use the exact triggering test run ID when available, otherwise find latest
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             WORKFLOW_RUN_ID="${{ github.event.workflow_run.id }}"
           else
@@ -454,20 +453,20 @@ jobs:
           fi
 
           if [ -z "$WORKFLOW_RUN_ID" ] || [ "$WORKFLOW_RUN_ID" = "null" ]; then
-            echo "No successful test run found. PDFs will not be included."
+            echo "No successful test run found. Release PDFs will not be included."
             echo "Tip: Run the test workflow first, then re-trigger this release."
             exit 0
           fi
 
-          echo "Downloading PDFs from test run: $WORKFLOW_RUN_ID"
+          echo "Downloading release PDFs from test run: $WORKFLOW_RUN_ID"
           if gh run download "$WORKFLOW_RUN_ID" \
               --repo "$GITHUB_REPOSITORY" \
-              --name all-compiled-documents \
-              --dir compiled-pdfs 2>/dev/null; then
+              --name release-pdfs \
+              --dir release-pdfs 2>/dev/null; then
             echo "Downloaded PDFs:"
-            ls -la compiled-pdfs/*.pdf
+            ls -la release-pdfs/*.pdf
           else
-            echo "Could not download compiled PDFs. Continuing without them."
+            echo "Could not download release PDFs. Continuing without them."
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -481,44 +480,66 @@ jobs:
           body: |
             ## TongjiThesis LaTeX Class v${{ env.PACKAGE_VERSION }}
 
-            [EDIT THIS SECTION: Add your release notes, changelog, and acknowledgments here]
+            [EDIT: 编写本版本的更新日志 | Write the changelog for this release]
 
-            This release contains multiple download options for the Tongji University undergraduate thesis template.
+            ### 新增 | New Features
 
-            ### Download Options
+            -
 
-            **CTAN Package** (for LaTeX package distribution):
+            ### 修正 | Fixes
+
+            -
+
+            ### 规范对齐 | Spec Alignment
+
+            -
+
+            ### 文档与维护 | Docs & Maintenance
+
+            -
+
+            ---
+
+            源文件下载见下方 Assets，或直接通过 GitHub 提供的 **Source code** (zip/tar.gz) 获取。| Source files available below, or use GitHub's auto-generated **Source code** archives.
+
+            ### 下载说明 | Download Options
+
+            **预编译示例 | Compiled Examples**:
+            - `TongjiThesis-v${{ env.PACKAGE_VERSION }}-science.pdf` — 理工科 (science/engineering)
+            - `TongjiThesis-v${{ env.PACKAGE_VERSION }}-humanities.pdf` — 文科 (humanities)
+
+            **CTAN 包 | CTAN Package** (LaTeX 包管理器分发 | for package distribution):
             - `tongjithesis-ctan-v${{ env.PACKAGE_VERSION }}.tar.gz`
             - `tongjithesis-ctan-v${{ env.PACKAGE_VERSION }}.zip`
 
-            **Complete Source Code** (for end users):
-            - `tongjithesis-source-v${{ env.PACKAGE_VERSION }}.tar.gz`
-            - `tongjithesis-source-v${{ env.PACKAGE_VERSION }}.zip`
+            ### 快速开始 | Quick Start
 
-            **Compiled Examples** (preview final output):
-            - PDFs compiled on Linux / macOS / Windows with XeLaTeX and LuaLaTeX
+            ```shell
+            git clone https://github.com/TJ-CSCCG/TongjiThesis.git
+            cd TongjiThesis && make
+            ```
 
-            ### Quick Start
+            或通过 [Overleaf 模板](https://www.overleaf.com/latex/templates/tongjithesis-tongji-university-thesis-template/tfvdvyggqybn) 零配置使用。| Or use the [Overleaf template](https://www.overleaf.com/latex/templates/tongjithesis-tongji-university-thesis-template/tfvdvyggqybn) for zero-config setup.
 
-            Download the source archive, extract, edit `main.tex`, and compile with XeLaTeX or LuaLaTeX.
+            ### 系统要求 | Requirements
 
-            ### Requirements
-            - XeLaTeX or LuaLaTeX engine
-            - Complete TeX distribution (TeX Live 2026+ recommended)
-            - Python with Pygments (optional, for minted code highlighting)
+            - XeLaTeX 或 LuaLaTeX 引擎 | XeLaTeX or LuaLaTeX engine
+            - TeX Live 2026+ 推荐 | TeX Live 2026+ recommended
+            - Python + Pygments（可选，用于 minted）| Python with Pygments (optional, for minted)
 
-            ### Links
-            - [GitHub Repository](https://github.com/TJ-CSCCG/TongjiThesis)
-            - [Overleaf Template](https://www.overleaf.com/latex/templates/tongji-university-undergraduate-thesis-template/tfvdvyggqybn)
+            ### 链接 | Links
+
+            - [GitHub](https://github.com/TJ-CSCCG/TongjiThesis)
+            - [Overleaf](https://www.overleaf.com/latex/templates/tongjithesis-tongji-university-thesis-template/tfvdvyggqybn)
+            - [CJK 字体仓库](https://github.com/TJ-CSCCG/cjk-fonts-for-ctex)
 
             ---
-            **Note**: This is a draft release. Edit the sections above and publish when ready.
+            **注意**: 此发布为草稿，请编辑上述各部分后再发布。| **Note**: This is a draft release. Edit the sections above before publishing.
           files: |
             ctan/tongjithesis-ctan-v${{ env.PACKAGE_VERSION }}.tar.gz
             ctan/tongjithesis-ctan-v${{ env.PACKAGE_VERSION }}.zip
-            tongjithesis-source-v${{ env.PACKAGE_VERSION }}.tar.gz
-            tongjithesis-source-v${{ env.PACKAGE_VERSION }}.zip
-            compiled-pdfs/tongjithesis-*.pdf
+            release-pdfs/TongjiThesis-v${{ env.PACKAGE_VERSION }}-science.pdf
+            release-pdfs/TongjiThesis-v${{ env.PACKAGE_VERSION }}-humanities.pdf
           draft: true
           prerelease: false
           fail_on_unmatched_files: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
             fullwidthstop=false,
             fontset=fandol,
             times=false,
-            minted=true,
+            minted=false,
             biblatex=true,
           ]{tongjithesis}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -186,8 +186,8 @@ jobs:
             pygments: true
           - variant: bibtex
             pygments: false
-          - variant: minimal
-            pygments: false
+          - variant: humanities-minted
+            pygments: true
           - variant: twoside
             pygments: false
           - variant: humanities
@@ -227,10 +227,11 @@ jobs:
         run: |
           sed -i 's/biblatex=true/biblatex=false/' main.tex
 
-      - name: Configure minimal variant (no biblatex)
-        if: matrix.variant == 'minimal'
+      - name: Configure humanities-minted variant
+        if: matrix.variant == 'humanities-minted'
         run: |
-          sed -i 's/biblatex=true/biblatex=false/' main.tex
+          sed -i 's/field=science/field=humanities/' main.tex
+          sed -i 's/minted=false/minted=true/' main.tex
 
       - name: Configure twoside variant
         if: matrix.variant == 'twoside'
@@ -248,14 +249,17 @@ jobs:
           if [ "${{ matrix.variant }}" = "minted-true" ]; then
             grep -q 'minted=true' main.tex || { echo "ERROR: minted=true not set"; exit 1; }
           fi
-          if [ "${{ matrix.variant }}" = "bibtex" ] || [ "${{ matrix.variant }}" = "minimal" ]; then
+          if [ "${{ matrix.variant }}" = "bibtex" ]; then
             grep -q 'biblatex=false' main.tex || { echo "ERROR: biblatex=false not set"; exit 1; }
           fi
           if [ "${{ matrix.variant }}" = "twoside" ]; then
             grep -q 'twoside' main.tex || { echo "ERROR: twoside not set"; exit 1; }
           fi
-          if [ "${{ matrix.variant }}" = "humanities" ]; then
+          if [ "${{ matrix.variant }}" = "humanities" ] || [ "${{ matrix.variant }}" = "humanities-minted" ]; then
             grep -q 'field=humanities' main.tex || { echo "ERROR: field=humanities not set"; exit 1; }
+          fi
+          if [ "${{ matrix.variant }}" = "humanities-minted" ]; then
+            grep -q 'minted=true' main.tex || { echo "ERROR: minted=true not set"; exit 1; }
           fi
 
       - name: Compile LaTeX document
@@ -318,4 +322,53 @@ jobs:
         with:
           name: all-compiled-documents
           path: "*.pdf"
+          retention-days: 90
+
+  # Build release PDFs on version tags (science + humanities, Linux xelatex-only)
+  build-release-pdfs:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - field: science
+            sed_science: ''
+          - field: humanities
+            sed_science: 's/field=science/field=humanities/'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install TeX Live
+        uses: tex-live/setup-texlive-action@v4
+        with:
+          version: 2026
+          packages: ${{ env.TL_PACKAGES }}
+        env:
+          SETUP_TEXLIVE_ACTION_NO_CACHE_ON_FAILURE: 1
+
+      - name: Configure field
+        if: matrix.field == 'humanities'
+        run: |
+          sed -i '${{ matrix.sed_science }}' main.tex
+
+      - name: Compile LaTeX document
+        run: |
+          make ENGINE=-xelatex all
+
+      - name: Rename PDF
+        if: success()
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          mv main.pdf "TongjiThesis-v${VERSION}-${{ matrix.field }}.pdf"
+
+      - name: Upload PDF
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-pdfs
+          path: TongjiThesis-v*.pdf
           retention-days: 90

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,9 +4,6 @@ on:
       - master
       - proposal
       - dev
-      - 'feat/**'
-      - 'fix/**'
-      - 'refactor/**'
     tags:
       - 'v*'
     paths-ignore:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -369,6 +369,6 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v7
         with:
-          name: release-pdfs
+          name: release-pdf-${{ matrix.field }}
           path: TongjiThesis-v*.pdf
           retention-days: 90


### PR DESCRIPTION
## 概要 | Summary

优化 CI 测试矩阵和 Release 发布流程：替换冗余变体、新增发布 PDF 构建任务、精简 Release Assets、消除 PR 推送与 PR 事件重复触发。

### 主要变更

- **替换 `minimal` → `humanities-minted` 变体**：`minimal` 与 `bibtex` 现在完全重复（`minted=false` 已是默认），替换为 `humanities+minted` 组合测试
- **新增 `build-release-pdfs` 任务**：在 tag 推送时构建 2 个发布用 PDF（`TongjiThesis-v{ver}-science.pdf` + `TongjiThesis-v{ver}-humanities.pdf`），发布时无需下载全部 11 个轮子 PDF
- **精简 Release Assets**：从 6 类文件减少至 4 个（2 PDF + 2 CTAN 包），移除源码压缩包（GitHub 自动生成 Source code zip/tar.gz）
- **更新 Release Body 模板**：结构化双语更新日志模板（新增/修正/规范对齐/文档与维护），与现有发布惯例一致
- **更新 CTAN example.tex**：`minted` 默认值从 `true` 改为 `false`
- **消除 CI 重复触发**：从 `push:` 中移除 `feat/**`、`fix/**`、`refactor/**`，避免与 `pull_request:` 事件产生双重运行

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [ ] 如涉及模板功能变更，已编写注释并更新对应文档。
- [ ] 如涉及模板功能变更，已尽可能在各平台上进行测试。