### PR TITLE
feat: add algo class option for algorithm2e support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,6 +78,7 @@ env:
     helvetic
     hologo
     ifplatform
+    ifoddpage
     lastpage
     latexmk
     lineno
@@ -114,6 +115,7 @@ env:
     xcolor
     xecjk
     xpatch
+    xspace
     xstring
     zhnumber
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,6 +96,7 @@ env:
     pict2e
     picture
     realscripts
+    relsize
     rsfs
     setspace
     siunitx

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,7 @@ env:
   # Packages needed for the thesis compilation
   TL_PACKAGES: |
     adjustbox
+    algorithm2e
     algorithmicx
     algorithms
     alphalph
@@ -189,6 +190,8 @@ jobs:
             pygments: false
           - variant: humanities
             pygments: false
+          - variant: algo-algorithm2e
+            pygments: false
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -240,6 +243,11 @@ jobs:
         run: |
           sed -i 's/field=science/field=humanities/' main.tex
 
+      - name: Configure algo=algorithm2e variant
+        if: matrix.variant == 'algo-algorithm2e'
+        run: |
+          sed -i 's/algo=algpseudocode/algo=algorithm2e/' main.tex
+
       - name: Verify variant configuration
         run: |
           git diff main.tex
@@ -257,6 +265,9 @@ jobs:
           fi
           if [ "${{ matrix.variant }}" = "humanities-minted" ]; then
             grep -q 'minted=true' main.tex || { echo "ERROR: minted=true not set"; exit 1; }
+          fi
+          if [ "${{ matrix.variant }}" = "algo-algorithm2e" ]; then
+            grep -q 'algo=algorithm2e' main.tex || { echo "ERROR: algo=algorithm2e not set"; exit 1; }
           fi
 
       - name: Compile LaTeX document

--- a/chapters/01_guide.tex
+++ b/chapters/01_guide.tex
@@ -24,6 +24,7 @@
     \texttt{fullwidthstop} & \texttt{circle} & 句号样式：\texttt{circle}（默认，保留“。”）或 \texttt{dot}（替换为“．”全角句点）。 \\
     \texttt{minted} & \texttt{false} & 代码高亮方案。\texttt{false} 使用 \pkg{listings}（默认，无外部依赖），\texttt{true} 使用 \pkg{minted}（需安装 Python 3.11–3.13 和 Pygments）。 \\
     \texttt{biblatex} & \texttt{true} & 参考文献方案。\texttt{true} 使用 \BibLaTeX{} + \texttt{biber}（功能更丰富），\texttt{false} 使用 \BibTeX{} + \pkg{gbt7714}（编译更快）。 \\
+    \texttt{algo} & \texttt{algpseudocode} & 算法排版方案。\texttt{algpseudocode}（默认）与 \texttt{algorithm2e} 语法不同，详见说明。 \\
     \bottomrule
   \end{tabular}
 \end{table}

--- a/chapters/03_float.tex
+++ b/chapters/03_float.tex
@@ -203,23 +203,41 @@
 
 \section{算法}
 
-算法环境可由 \pkg{algorithm} + \pkg{algpseudocode}（本模板已加载）或较新的 \pkg{algorithm2e} 宏包实现。
-\cref{algo:algorithm} 是一个使用 \pkg{algpseudocode} 的示例。
+本模板默认使用 \pkg{algpseudocode} 排版算法，也可通过文档类选项 \texttt{algo=algorithm2e} 切换为 \pkg{algorithm2e}。
 
-\begin{algorithm}
-  \caption{计算斐波那契数列}\label{algo:algorithm}
-  \begin{algorithmic}[1]
-    \Require $n \geq 0$
-    \Ensure $fib(n)$
-    \Function{Fibonacci}{$n$}
-    \If{$n \leq 1$}
-    \State \Return $n$
-    \Else
-    \State \Return \Call{Fibonacci}{$n-1$} + \Call{Fibonacci}{$n-2$}
-    \EndIf
-    \EndFunction
-  \end{algorithmic}
-\end{algorithm}
+\iftjalgorithmtwoe
+  \cref{algo:algorithm} 是一个使用 \pkg{algorithm2e} 的示例。
+
+  \SetKw{Return}{return}
+  \begin{algorithm}[H]
+    \caption{计算斐波那契数列}\label{algo:algorithm}
+    \SetKwFunction{Fib}{Fibonacci}
+    \KwIn{$n \geq 0$}
+    \KwOut{$fib(n)$}
+    \Fib{$n$}\;
+    \If{$n \leq 1$}{\Return $n$\;}
+    \Return \Fib{$n-1$} + \Fib{$n-2$}\;
+  \end{algorithm}
+\else
+  \cref{algo:algorithm} 是一个使用 \pkg{algpseudocode} 的示例。
+
+  \begin{algorithm}
+    \caption{计算斐波那契数列}\label{algo:algorithm}
+    \begin{algorithmic}[1]
+      \Require $n \geq 0$
+      \Ensure $fib(n)$
+      \Function{Fibonacci}{$n$}
+      \If{$n \leq 1$}
+      \State \Return $n$
+      \Else
+      \State \Return \Call{Fibonacci}{$n-1$} + \Call{Fibonacci}{$n-2$}
+      \EndIf
+      \EndFunction
+    \end{algorithmic}
+  \end{algorithm}
+\fi
+
+无论使用 \pkg{algpseudocode} 还是 \pkg{algorithm2e}，都可以通过相应的命令来定义函数、条件语句和循环结构，以便于编写清晰易懂的算法描述。
 
 \section{代码}
 

--- a/main.tex
+++ b/main.tex
@@ -7,6 +7,7 @@
   times=false,
   minted=false,
   biblatex=true,
+  algo=algpseudocode,
 ]{tongjithesis}
 
 \tjbibresource{bib/note.bib}

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -49,6 +49,9 @@
 % 经管类属社科：编号要求依理工，撰写依理工模版。26 届为过渡期，可选 science 或
 % humanities；自 27 届起统一使用 science。
 \DeclareStringOption[science]{field}
+% Define algo option: algpseudocode (default, algorithm + algorithmicx + algpseudocode),
+% algorithm2e (standalone algorithm2e package)
+\DeclareStringOption[algpseudocode]{algo}
 
 \DeclareDefaultOption{\PassOptionsToClass{\CurrentOption}{ctexbook}}
 \ProcessKeyvalOptions*
@@ -70,6 +73,11 @@
     \ClassWarning{tongjithesis}{field=\tongjithesis@field\space is unknown. Falling back to science format}%
   }%
 }
+\newif\iftongjithesis@algorithmtwoe
+\expandafter\ifstrequal\expandafter{\tongjithesis@algo}{algorithm2e}{%
+  \tongjithesis@algorithmtwoetrue
+}{}{}
+\let\iftjalgorithmtwoe\iftongjithesis@algorithmtwoe
 
 % ==========================================
 % Class Loading
@@ -187,9 +195,15 @@
 \captionsetup[sub]{font={tj@caption,tj@songti}}
 
 % Algorithms and code listings
-\RequirePackage{algorithm}
-\RequirePackage{algorithmicx}
-\RequirePackage{algpseudocode}
+\iftongjithesis@algorithmtwoe
+  \RequirePackage[ruled,linesnumbered,algochapter]{algorithm2e}
+  \let\c@algorithm\c@algocf
+  \renewcommand{\thealgocf}{\thealgorithm}
+\else
+  \RequirePackage{algorithm}
+  \RequirePackage{algorithmicx}
+  \RequirePackage{algpseudocode}
+\fi
 
 % Always load listings package first (mandatory)
 \RequirePackage{listings}
@@ -823,26 +837,36 @@
 % ==========================================
 
 % 伪代码
-\renewcommand{\algorithmicrequire}{\textbf{输入: }}
-\renewcommand{\algorithmicensure}{\textbf{输出: }}
-\renewenvironment{algorithm}
-{
-  \vskip 20pt
-  \refstepcounter{algorithm}% New algorithm
-  \hrule height.8pt depth0pt \kern2pt% \@fs@pre for \@fs@ruled
-  \renewcommand{\caption}[2][\relax]{% 使用中文 caption
-    {\raggedright\textbf{算法~\thealgorithm} ##2\par}%
-    \ifx\relax##1\relax % #1 is \relax
-      \addcontentsline{loa}{algorithm}{\protect\numberline{\thealgorithm}##2}%
-    \else % #1 is not \relax
-      \addcontentsline{loa}{algorithm}{\protect\numberline{\thealgorithm}##1}%
-    \fi
-    \kern2pt\hrule\kern2pt
-  }
-}{
-  \kern2pt\hrule\relax
-  \vskip 20pt
-}% \@fs@post for \@fs@ruled
+\iftongjithesis@algorithmtwoe
+  \SetAlgorithmName{算法}{算法}{算法列表}
+  \SetKwInput{KwIn}{输入}
+  \SetKwInput{KwOut}{输出}
+  \gdef\algocf@Vspace{\vskip\baselineskip\relax}
+  \AtBeginEnvironment{algorithm}{\linespread{1.0}\selectfont}
+  \AfterEndEnvironment{algorithm}{\vspace{\baselineskip}}
+\else
+  \renewcommand{\algorithmicrequire}{\textbf{输入: }}
+  \renewcommand{\algorithmicensure}{\textbf{输出: }}
+  \AtBeginEnvironment{algorithmic}{\linespread{1.0}\selectfont}
+  \renewenvironment{algorithm}
+  {
+    \vskip\baselineskip
+    \refstepcounter{algorithm}% New algorithm
+    \hrule height.8pt depth0pt \kern2pt% \@fs@pre for \@fs@ruled
+    \renewcommand{\caption}[2][\relax]{% 使用中文 caption
+      {\raggedright\textbf{算法~\thealgorithm} ##2\par}%
+      \ifx\relax##1\relax % #1 is \relax
+        \addcontentsline{loa}{algorithm}{\protect\numberline{\thealgorithm}##2}%
+      \else % #1 is not \relax
+        \addcontentsline{loa}{algorithm}{\protect\numberline{\thealgorithm}##1}%
+      \fi
+      \kern2pt\hrule\kern2pt
+    }
+  }{
+    \kern2pt\hrule\relax
+    \vskip\baselineskip
+  }% \@fs@post for \@fs@ruled
+\fi
 
 % ==========================================
 % Cross-Referencing Commands
@@ -905,6 +929,9 @@
 \crefformat{algorithm}{#2算法~#1#3}
 \crefmultiformat{algorithm}{#2算法~#1#3}{和#2算法~#1#3}{、#2算法~#1#3}{和#2算法~#1#3}
 \crefrangeformat{algorithm}{#3算法~#1#4~至#5算法~#2#6}
+\crefformat{algocf}{#2算法~#1#3}
+\crefmultiformat{algocf}{#2算法~#1#3}{和#2算法~#1#3}{、#2算法~#1#3}{和#2算法~#1#3}
+\crefrangeformat{algocf}{#3算法~#1#4~至#5算法~#2#6}
 \crefformat{FancyVerbLine}{#2第~#1~行#3}
 \crefmultiformat{FancyVerbLine}{#2第~#1~行#3}{和#2第~#1~行#3}{、#2第~#1~行#3}{和#2第~#1~行#3}
 \crefrangeformat{FancyVerbLine}{#3第~#1~行#4至#5第~#2~行#6}


### PR DESCRIPTION
## 概要 | Summary

新增 `algo` 文档类选项，允许用户在 `algpseudocode`（默认）与 `algorithm2e` 之间切换算法排版方案。

### 变更内容
- 新增 `algo=algpseudocode`（默认）或 `algo=algorithm2e` 文档类选项
- 条件加载宏包：默认使用 `algorithm` + `algorithmicx` + `algpseudocode`，`algo=algorithm2e` 使用独立 `algorithm2e` 宏包
- 中文关键词本地化：两种模式均支持中文输入/输出（algpseudocode 的 `\Require`/`\Ensure`，algorithm2e 的 `\KwIn`/`\KwOut`）
- 计数器兼容：algorithm2e 的 `algocf` 计数器通过别名绑定，`\counterwithin` 等命令透明工作
- `03_float.tex` 中根据选项条件展示对应用例
- 算法环境统一单倍行距 + 上下 `\baselineskip` 间距
- CI 新增 `algo=algorithm2e` 编译变体（所有平台和变体均通过）

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

无。

## 截图 | Screenshots

algpseudocode 与 algorithm2e 两种模式均在本地 xelatex 编译通过，CI 全平台通过。