### PR TITLE
feat: support 2-line wrap and horizontal shrink on cover fields

### DIFF
--- a/chapters/metadata.tex
+++ b/chapters/metadata.tex
@@ -12,8 +12,8 @@
 \school{计算机科学与技术学院}
 \major{计算机科学与技术}
 \student{2654321}{张同舟}
-\thesistitle{\TongjiThesis{}同济大学本科毕业设计论文模板与\LaTeX{}排版技术应用}{面向同济大学本科毕业设计的学术写作与自动排版指南}
-\thesistitleeng{\TongjiThesis{} Template and \LaTeX{} Typesetting for Tongji University Capstone Design}{A Guide to Academic Writing and Automated Typesetting for Undergraduate Thesis}
+\thesistitle{\TongjiThesis{}同济大学本科毕业设计（论文）模板与\LaTeX{}排版技术应用}{模板排版功能示例、学术写作规范与格式设置指南}
+\thesistitleeng{\TongjiThesis{} Template and \LaTeX{} Typesetting for Tongji University Undergraduate Thesis}{A Guide to Typesetting Features, Academic Writing Standards, and Formatting}
 \thesisadvisor{李共济\quad 教授}
 \thesisdate{\the\year}{\the\month}{\the\day} % 使用当前日期; 也可以自定义日期
 

--- a/chapters/metadata.tex
+++ b/chapters/metadata.tex
@@ -12,8 +12,8 @@
 \school{计算机科学与技术学院}
 \major{计算机科学与技术}
 \student{2654321}{张同舟}
-\thesistitle{\TongjiThesis{} 论文模板使用示例}{\LaTeX{}排版技术在学术写作中的应用}
-\thesistitleeng{\TongjiThesis{} Template Usage Example}{Application of \LaTeX{} Typesetting in Academic Writing}
+\thesistitle{\TongjiThesis{}同济大学本科毕业设计论文模板与\LaTeX{}排版技术应用}{面向同济大学本科毕业设计的学术写作与自动排版指南}
+\thesistitleeng{\TongjiThesis{} Template and \LaTeX{} Typesetting for Tongji University Capstone Design}{A Guide to Academic Writing and Automated Typesetting for Undergraduate Thesis}
 \thesisadvisor{李共济\quad 教授}
 \thesisdate{\the\year}{\the\month}{\the\day} % 使用当前日期; 也可以自定义日期
 

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -992,17 +992,36 @@
 
 \newlength{\covertextwidth}
 \newlength{\covermaxwidth}
+\newlength{\coverparwidth}
 
 \newcommand{\ulinecentered}[1]{
   \setlength{\covertextwidth}{\widthof{#1}}
-  \setlength{\covermaxwidth}{20em} % Set the maximum width you allow
-  \ifthenelse{\lengthtest{\covertextwidth > \covermaxwidth}}{
-    % Calculate scale factor and scale down text if too wide
-    \pgfmathsetmacro{\scalefactor}{\covermaxwidth/\covertextwidth}
-    \uline{\makebox[\covermaxwidth][c]{\scalebox{\scalefactor}[1]{#1}}}
-  }{
-    \uline{\makebox[\covermaxwidth][c]{#1}} % Use normal text if within the limit
-  }
+  \setlength{\covermaxwidth}{20em}
+  \ifdim\covertextwidth > \covermaxwidth
+    \ifdim\covertextwidth > 1.95\covermaxwidth
+      \setlength{\coverparwidth}{0.53\covertextwidth}
+      \pgfmathsetmacro{\coverscale}{\covermaxwidth / \coverparwidth}
+      \uline{%
+        \scalebox{\coverscale}[1]{%
+          \parbox[b]{\coverparwidth}{%
+            \centering
+            \renewcommand{\baselinestretch}{0.8}\selectfont
+            #1%
+          }%
+        }%
+      }
+    \else
+      \uline{%
+        \parbox[b]{\covermaxwidth}{%
+          \centering
+          \renewcommand{\baselinestretch}{0.8}\selectfont
+          #1%
+        }%
+      }
+    \fi
+  \else
+    \uline{\makebox[\covermaxwidth][c]{#1}}
+  \fi
 }
 
 % 论文基本信息配置


### PR DESCRIPTION
## 概要 | Summary

将封面字段 `\ulinecentered` 从单行扩展为三档逻辑，使较长标题/副标题可以自然换行为两行，并在超长时水平压缩以保持封面整洁。

Replace single-line `\ulinecentered` with three-branch logic so longer titles/subtitles can wrap to 2 lines naturally, and horizontally shrink when they exceed even that.

## 检查清单 | Checklist

- [x] 已通读贡献指南。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 已通过 `make cleanall && make` 编译验证（40 页，无错误）。

## 关联 Issue | Related Issues

（无）

## 截图 | Screenshots

改动说明：

| 文本宽度 | 行为 |
|---|---|
| ≤20em | 单行 `\uline{\makebox}`（不变） |
| 20em–1.95×20em | 在 20em `\parbox` 内自然换行至 2 行，紧凑行距 |
| >1.95×20em | `\parbox` 宽度为 `0.53×textwidth` 实现大致均匀两行，再通过 `\scalebox` 纯水平压缩至 20em |

同时更新了示例元数据标题为中英文适中长度（~28em），以展示中间档的效果。

<img width="1494" height="622" alt="image" src="https://github.com/user-attachments/assets/6b9d41ce-6f8c-4399-a10b-e2e17ea3baac" />
