### PR TITLE
fix: correct keyword indent and spacing in CN/EN abstracts

### DIFF
--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -1169,7 +1169,7 @@
   \end{spacing}
 
   \vspace{1em}%
-  \noindent{\songti\tjfontbody{\textbf{关键词：}#2}\par}
+  \songti\tjfontbody{\noindent\textbf{关键词：}#2}\par
 }
 
 % 设置英文摘要页
@@ -1194,8 +1194,8 @@
     \par
   \end{spacing}
 
-  \vspace{1em}
-  \noindent{\tjfontbody\textbf{Key words: }#2\par}
+  \vspace{1em}%
+  \tjfontbody{\noindent\textbf{Key words: }#2}\par
 }
 
 % ==========================================

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -1168,8 +1168,9 @@
     \par
   \end{spacing}
 
-  \vspace{1em}%
-  \songti\tjfontbody{\noindent\textbf{关键词：}#2}\par
+  \songti\tjfontbody
+  \vspace{\baselineskip}
+  {\noindent\textbf{关键词：}#2}\par
 }
 
 % 设置英文摘要页
@@ -1194,8 +1195,9 @@
     \par
   \end{spacing}
 
-  \vspace{1em}%
-  \tjfontbody{\noindent\textbf{Key words: }#2}\par
+  \tjfontbody
+  \vspace{\baselineskip}
+  {\noindent\textbf{Key words: }#2}\par
 }
 
 % ==========================================

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -1168,10 +1168,8 @@
     \par
   \end{spacing}
 
-  \vskip 5mm
-  \noindent{\songti\tjfontbody{%
-      \textbf{关键词：}#2
-    }}~\\
+  \vspace{1em}%
+  \noindent{\songti\tjfontbody{\textbf{关键词：}#2}\par}
 }
 
 % 设置英文摘要页
@@ -1197,10 +1195,7 @@
   \end{spacing}
 
   \vspace{1em}
-  \noindent{\tjfontbody
-    \textbf{Key words: }#2
-  }
-  \par
+  \noindent{\tjfontbody\textbf{Key words: }#2\par}
 }
 
 % ==========================================


### PR DESCRIPTION
## 概要 | Summary

修复摘要页关键词行的缩进和间距问题：

1. **缩进修复**：将 `\noindent` 移入组内确保关键词行零缩进，与正文首行缩进形成合理对比
2. **间距修复**：将 `\vskip 5mm`（CN）和 `\vspace{1em}`（EN）替换为 `\vspace{\baselineskip}`，在正文与关键词之间留出一个完整空行
3. **格式统一**：CN 与 EN 摘要的关键词行结构保持一致

Fix keyword indent and spacing in CN/EN abstracts:
- Properly suppress indent on keyword line
- Replace hardcoded spacing with \baselineskip for one full empty line
- Unify CN/EN formatting

## 检查清单 | Checklist

- [x] 已通读贡献指南。
- [x] 已通过 `make cleanall && make` 编译验证。

<img width="816" height="394" alt="image" src="https://github.com/user-attachments/assets/bcea5adf-5d55-4c71-9550-857443d24c6e" />

## 关联 Issue | Related Issues

Closes #110