### PR TITLE
feat: \abstracttitle command and cover-only \\ line breaks

### DIFF
--- a/chapters/01_guide.tex
+++ b/chapters/01_guide.tex
@@ -34,9 +34,11 @@
 论文的封面、信息说明页与中英文摘要的个人信息分散在 \verb|chapters/| 目录下的两个文件中。各文件均已提供带注释的示例，照搬并替换字段值即可；模板据此自动生成对应页面。
 
 \begin{itemize}
-  \item \textbf{封面与信息说明页} —— \verb|chapters/metadata.tex|：\cs{school}、\cs{major}、\cs{student}、\cs{thesistitle}、\cs{thesistitleeng}、\cs{thesisadvisor}、\cs{thesisdate}（封面），以及 \cs{infotype}（\texttt{thesis}、\texttt{design} 或 \texttt{engineering}）、\cs{infoabstract}、\cs{infothesiswords}（论文）或 \cs{infodrawings}+\cs{infowordcount}（设计）、\cs{infomaterials}（信息说明页）。封面与信息说明页由随后的 \cs{MakeCover}、\cs{MakeInfoPage} 命令自动生成。
-  \item \textbf{中英文摘要} —— \verb|chapters/00_abstract.tex|：\cs{MakeAbstract}\verb|{正文}{关键词}| 与 \cs{MakeAbstractEng}\verb|{Text}{Keywords}|。
+  \item \textbf{封面与信息说明页} —— \verb|chapters/metadata.tex|：\cs{school}、\cs{major}、\cs{student}、\cs{thesistitle}、\cs{thesistitleeng}、\cs{thesisadvisor}、\cs{thesisdate}（封面），以及 \cs{infotype}（\texttt{thesis}、\texttt{design} 或 \texttt{engineering}）、\cs{infoabstract}、\cs{infothesiswords}（毕业论文）或 \cs{infodrawings} + \cs{infowordcount}（毕业设计）、\cs{infomaterials}（信息说明页）。封面与信息说明页由随后的 \cs{MakeCover}、\cs{MakeInfoPage} 命令自动生成。
+  \item \textbf{中英文摘要} —— \verb|chapters/00_abstract.tex|：\cs{MakeAbstract}\verb|{正文}{关键词}| 与 \cs{MakeAbstractEng}\verb|{Text}{Keywords}|，以及可选的摘要标题 \cs{abstracttitle} 与 \cs{abstracttitleeng}。
 \end{itemize}
+
+可在 \cs{thesistitle} 与 \cs{thesistitleeng} 中使用 \verb|\\| 为封面标题手动添加换行，信息说明页标题会自动移除这些换行。若中英文摘要页标题需要使用独立换行位置，可在 \verb|chapters/metadata.tex| 中设置 \cs{abstracttitle}\verb|{摘要中文标题}{摘要中文副标题}| 与 \cs{abstracttitleeng}\verb|{Abstract English Title}{Abstract English Subtitle}|；未设置 \cs{abstracttitle} 与 \cs{abstracttitleeng} 时，中英文摘要页标题会沿用 \cs{thesistitle} 与 \cs{thesistitleeng}，并自动移除这些换行。
 
 \section{文档结构}
 

--- a/chapters/01_guide.tex
+++ b/chapters/01_guide.tex
@@ -35,12 +35,10 @@
 
 \begin{itemize}
   \item \textbf{封面与信息说明页} —— \verb|chapters/metadata.tex|：\cs{school}、\cs{major}、\cs{student}、\cs{thesistitle}、\cs{thesistitleeng}、\cs{thesisadvisor}、\cs{thesisdate}（封面），以及 \cs{infotype}（\texttt{thesis}、\texttt{design} 或 \texttt{engineering}）、\cs{infoabstract}、\cs{infothesiswords}（毕业论文）或 \cs{infodrawings} + \cs{infowordcount}（毕业设计）、\cs{infomaterials}（信息说明页）。封面与信息说明页由随后的 \cs{MakeCover}、\cs{MakeInfoPage} 命令自动生成。
-  \item \textbf{中英文摘要} —— \verb|chapters/00_abstract.tex|：\cs{MakeAbstract}\verb|{正文}{关键词}| 与 \cs{MakeAbstractEng}\verb|{Text}{Keywords}|，以及可选的摘要标题 \cs{abstracttitle} 与 \cs{abstracttitleeng}。
+  \item \textbf{中英文摘要} —— \verb|chapters/00_abstract.tex|：\cs{MakeAbstract}\verb|{正文}{关键词}| 与 \cs{MakeAbstractEng}\verb|{Text}{Keywords}|，以及可选的摘要页论文标题 \cs{abstracttitle} 与 \cs{abstracttitleeng}。
 \end{itemize}
 
-可在 \cs{thesistitle} 与 \cs{thesistitleeng} 中使用 \verb|\\| 为封面标题手动添加换行，信息说明页标题会自动移除这些换行。若中英文摘要页标题需要使用独立换行位置，可在 \verb|chapters/metadata.tex| 中设置 \cs{abstracttitle}\verb|{摘要中文标题}{摘要中文副标题}| 与 \cs{abstracttitleeng}\verb|{Abstract English Title}{Abstract English Subtitle}|；未设置 \cs{abstracttitle} 与 \cs{abstracttitleeng} 时，中英文摘要页标题会沿用 \cs{thesistitle} 与 \cs{thesistitleeng}，并自动移除这些换行。
-
-\noindent\textbf{注意：}\cs{abstracttitle} 与 \cs{abstracttitleeng} 设置的是摘要页中展示的\textbf{论文标题}，而非摘要本身的标题（摘要标题固定为「摘要」与「Abstract」）。
+可在 \cs{thesistitle} 与 \cs{thesistitleeng} 中使用 \verb|\\| 为封面标题手动添加换行，信息说明页标题会自动移除这些换行。若中英文摘要页需要使用独立换行位置，可在 \verb|chapters/metadata.tex| 中设置 \cs{abstracttitle}\verb|{摘要中文标题}{摘要中文副标题}| 与 \cs{abstracttitleeng}\verb|{Abstract English Title}{Abstract English Subtitle}|；未设置 \cs{abstracttitle} 与 \cs{abstracttitleeng} 时，中英文摘要页论文标题会沿用 \cs{thesistitle} 与 \cs{thesistitleeng}，并自动移除这些换行。
 
 \section{文档结构}
 

--- a/chapters/01_guide.tex
+++ b/chapters/01_guide.tex
@@ -40,6 +40,8 @@
 
 可在 \cs{thesistitle} 与 \cs{thesistitleeng} 中使用 \verb|\\| 为封面标题手动添加换行，信息说明页标题会自动移除这些换行。若中英文摘要页标题需要使用独立换行位置，可在 \verb|chapters/metadata.tex| 中设置 \cs{abstracttitle}\verb|{摘要中文标题}{摘要中文副标题}| 与 \cs{abstracttitleeng}\verb|{Abstract English Title}{Abstract English Subtitle}|；未设置 \cs{abstracttitle} 与 \cs{abstracttitleeng} 时，中英文摘要页标题会沿用 \cs{thesistitle} 与 \cs{thesistitleeng}，并自动移除这些换行。
 
+\noindent\textbf{注意：}\cs{abstracttitle} 与 \cs{abstracttitleeng} 设置的是摘要页中展示的\textbf{论文标题}，而非摘要本身的标题（摘要标题固定为「摘要」与「Abstract」）。
+
 \section{文档结构}
 
 \verb|main.tex| 已预置了完整的论文结构，用户只需修改各 \verb|\input| 文件的内容：

--- a/chapters/metadata.tex
+++ b/chapters/metadata.tex
@@ -44,3 +44,10 @@
   \item 随附材料名称一（如：全套图纸、程序源代码、计算书等）；
   \item 随附材料名称二
 }
+
+% ============================================================
+%  中英文摘要页
+% ============================================================
+% 摘要页标题（可选）：未设置或两个参数都留空时，沿用 \thesistitle 与 \thesistitleeng，如需让摘要页使用不同标题或独立换行位置，取消以下两行注释。
+% \abstracttitle{\TongjiThesis{}同济大学本科毕业设计（论文）模板与\LaTeX{}排版技术应用}{模板排版功能示例、学术写作规范与格式设置指南}
+% \abstracttitleeng{\TongjiThesis{} Template and \LaTeX{} Typesetting for Tongji University Undergraduate Thesis}{A Guide to Typesetting Features, Academic Writing Standards, and Formatting}

--- a/chapters/metadata.tex
+++ b/chapters/metadata.tex
@@ -48,6 +48,6 @@
 % ============================================================
 %  中英文摘要页
 % ============================================================
-% 摘要页标题（可选）：未设置或两个参数都留空时，沿用 \thesistitle 与 \thesistitleeng，如需让摘要页使用不同标题或独立换行位置，取消以下两行注释。
+% 摘要页论文标题（可选）：设置摘要页展示的论文标题（非摘要 section 名称）。未设置或两个参数都留空时，沿用 \thesistitle 与 \thesistitleeng，如需让摘要页使用不同标题或独立换行位置，取消以下两行注释。
 % \abstracttitle{\TongjiThesis{}同济大学本科毕业设计（论文）模板与\LaTeX{}排版技术应用}{模板排版功能示例、学术写作规范与格式设置指南}
 % \abstracttitleeng{\TongjiThesis{} Template and \LaTeX{} Typesetting for Tongji University Undergraduate Thesis}{A Guide to Typesetting Features, Academic Writing Standards, and Formatting}

--- a/style/tongjithesis.cfg
+++ b/style/tongjithesis.cfg
@@ -10,6 +10,10 @@
 \def\tongjithesissubtitle{}
 \def\tongjithesistitleeng{}
 \def\tongjithesissubtitleeng{}
+\def\tongjiabstracttitle{}
+\def\tongjiabstractsubtitle{}
+\def\tongjiabstracttitleeng{}
+\def\tongjiabstractsubtitleeng{}
 \def\tongjithesisadvisor{}
 \def\tongjithesisyear{}
 \def\tongjithesismonth{}

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -1039,6 +1039,39 @@
   \fi
 }
 
+\def\tj@titlecnbreak@opt[#1]{\unskip\ignorespaces}
+\def\tj@titlecnbreak@star*{%
+  \@ifnextchar[{\tj@titlecnbreak@opt}{\unskip\ignorespaces}%
+}
+\newcommand{\tjtitlecninlinebreak}{%
+  \unskip
+  \@ifnextchar*{\tj@titlecnbreak@star}{%
+    \@ifnextchar[{\tj@titlecnbreak@opt}{\ignorespaces}%
+  }%
+}
+\newcommand{\tjtitlecninline}[1]{%
+  \begingroup
+    \let\\\tjtitlecninlinebreak
+    #1%
+  \endgroup
+}
+\def\tj@titleenbreak@opt[#1]{\unskip\space\ignorespaces}
+\def\tj@titleenbreak@star*{%
+  \@ifnextchar[{\tj@titleenbreak@opt}{\unskip\space\ignorespaces}%
+}
+\newcommand{\tjtitleeninlinebreak}{%
+  \unskip
+  \@ifnextchar*{\tj@titleenbreak@star}{%
+    \@ifnextchar[{\tj@titleenbreak@opt}{\space\ignorespaces}%
+  }%
+}
+\newcommand{\tjtitleeninline}[1]{%
+  \begingroup
+    \let\\\tjtitleeninlinebreak
+    #1%
+  \endgroup
+}
+
 % 论文基本信息配置
 \newcommand{\school}[1]{\def\tongjischool{#1}}
 \newcommand{\major}[1]{\def\tongjimajor{#1}}
@@ -1122,8 +1155,8 @@
     \setlength{\parindent}{0pt}
 
     \savebox{\tj@titlebox}{\parbox[t]{\dimexpr\linewidth-5em\relax}{%
-      \tongjithesistitle
-      \ifx\tongjithesissubtitle\empty\else ——\tongjithesissubtitle\fi
+      \tjtitlecninline{\tongjithesistitle}%
+      \ifx\tongjithesissubtitle\empty\else——\tjtitlecninline{\tongjithesissubtitle}\fi
     }}%
     \infoline{课题名称}{\usebox{\tj@titlebox}}%
     \settodepth{\tj@titledp}{\usebox{\tj@titlebox}}%
@@ -1167,9 +1200,9 @@
   \begin{center}\bfseries\heiti\tjfonttitle
     \ \\
     \vspace{-0.5em}
-    \tongjithesistitle
+    \tjtitlecninline{\tongjithesistitle}
     \ifx\tongjithesissubtitle\empty\else
-      \\[0.2em]{\zihao{3}\tongjithesissubtitle}% 副标题：三号（官方模板规范）
+      \\[0.2em]{\zihao{3}\tjtitlecninline{\tongjithesissubtitle}}% 副标题：三号（官方模板规范）
     \fi
   \end{center}
   \vspace{-0.8em}
@@ -1194,9 +1227,9 @@
   \begin{center}\tjfonttitle
     \ \\
     \vspace{-0.5em}
-    \textbf{\tongjithesistitleeng}
+    \textbf{\tjtitleeninline{\tongjithesistitleeng}}
     \ifx\tongjithesissubtitleeng\empty\else
-      \\[0.2em]{\zihao{3}\textbf{\tongjithesissubtitleeng}}% 副标题：三号（官方模板规范）
+      \\[0.2em]{\zihao{3}\textbf{\tjtitleeninline{\tongjithesissubtitleeng}}}% 副标题：三号（官方模板规范）
     \fi
   \end{center}
   \vspace{-0.8em}

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -1073,11 +1073,25 @@
 }
 
 % 论文基本信息配置
+\newif\iftj@abstracttitle@set
+\newif\iftj@abstracttitleeng@set
 \newcommand{\school}[1]{\def\tongjischool{#1}}
 \newcommand{\major}[1]{\def\tongjimajor{#1}}
 \newcommand{\student}[2]{\def\tongjiauthornumber{#1}\def\tongjiauthor{#2}}
 \newcommand{\thesistitle}[2]{\def\tongjithesistitle{#1}\def\tongjithesissubtitle{#2}}
 \newcommand{\thesistitleeng}[2]{\def\tongjithesistitleeng{#1}\def\tongjithesissubtitleeng{#2}}
+\newcommand{\abstracttitle}[2]{%
+  \def\tongjiabstracttitle{#1}\def\tongjiabstractsubtitle{#2}%
+  \ifstrempty{#1}{%
+    \ifstrempty{#2}{\tj@abstracttitle@setfalse}{\tj@abstracttitle@settrue}%
+  }{\tj@abstracttitle@settrue}%
+}
+\newcommand{\abstracttitleeng}[2]{%
+  \def\tongjiabstracttitleeng{#1}\def\tongjiabstractsubtitleeng{#2}%
+  \ifstrempty{#1}{%
+    \ifstrempty{#2}{\tj@abstracttitleeng@setfalse}{\tj@abstracttitleeng@settrue}%
+  }{\tj@abstracttitleeng@settrue}%
+}
 \newcommand{\thesisadvisor}[1]{\def\tongjithesisadvisor{#1}}
 \newcommand{\thesisdate}[3]{\def\tongjithesisyear{#1}\def\tongjithesismonth{#2}\def\tongjithesisday{#3}}
 
@@ -1200,10 +1214,20 @@
   \begin{center}\bfseries\heiti\tjfonttitle
     \ \\
     \vspace{-0.5em}
-    \tjtitlecninline{\tongjithesistitle}
-    \ifx\tongjithesissubtitle\empty\else
-      \\[0.2em]{\zihao{3}\tjtitlecninline{\tongjithesissubtitle}}% 副标题：三号（官方模板规范）
-    \fi
+    \parbox[t]{\linewidth}{%
+      \centering
+      \iftj@abstracttitle@set
+        \tongjiabstracttitle
+        \ifx\tongjiabstractsubtitle\empty\else
+          \\[0.2em]{\zihao{3}\tongjiabstractsubtitle}% 副标题：三号（官方模板规范）
+        \fi
+      \else
+        \tjtitlecninline{\tongjithesistitle}%
+        \ifx\tongjithesissubtitle\empty\else
+          \\[0.2em]{\zihao{3}\tjtitlecninline{\tongjithesissubtitle}}% 副标题：三号（官方模板规范）
+        \fi
+      \fi
+    }%
   \end{center}
   \vspace{-0.8em}
   \begin{center}\heiti\tjfontheading
@@ -1227,10 +1251,20 @@
   \begin{center}\tjfonttitle
     \ \\
     \vspace{-0.5em}
-    \textbf{\tjtitleeninline{\tongjithesistitleeng}}
-    \ifx\tongjithesissubtitleeng\empty\else
-      \\[0.2em]{\zihao{3}\textbf{\tjtitleeninline{\tongjithesissubtitleeng}}}% 副标题：三号（官方模板规范）
-    \fi
+    \parbox[t]{\linewidth}{%
+      \centering
+      \iftj@abstracttitleeng@set
+        \textbf{\tongjiabstracttitleeng}%
+        \ifx\tongjiabstractsubtitleeng\empty\else
+          \\[0.2em]{\zihao{3}\textbf{\tongjiabstractsubtitleeng}}% 副标题：三号（官方模板规范）
+        \fi
+      \else
+        \textbf{\tjtitleeninline{\tongjithesistitleeng}}%
+        \ifx\tongjithesissubtitleeng\empty\else
+          \\[0.2em]{\zihao{3}\textbf{\tjtitleeninline{\tongjithesissubtitleeng}}}% 副标题：三号（官方模板规范）
+        \fi
+      \fi
+    }%
   \end{center}
   \vspace{-0.8em}
   \begin{center}\tjfontheading


### PR DESCRIPTION
## 概要 | Summary

请简要描述本 PR 所做的工作 | Brief description of the changes:

- 允许 `\thesistitle` 和 `\thesistitleeng` 中的 `\\` 仅用于封面换行。
- 信息说明页、中文摘要页使用中文 inline 标题渲染：将标题中的 `\\` 移除。
- 英文摘要页使用英文 inline 标题渲染：将标题中的 `\\` 转换为空格。
- 兼容 `\\`、`\\*`、`\\[...]` 等 LaTeX 换行写法。
- 新增 `\abstracttitle` / `\abstracttitleeng` 可选命令，支持摘要页独立设置论文标题及换行位置；未设置时回退到 `\thesistitle` / `\thesistitleeng`。

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

无。