### PR TITLE
fix: add `\raggedbottom` to prevent uneven spacing in twoside mode

### DIFF
--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -408,7 +408,8 @@
 % book 文档类在 twoside 模式下默认启用 \flushbottom，强制所有页面底部对齐，
 % 这会拉伸 \parskip 等带 stretch 的垂直间距，导致标题附近的空行行距不均匀。
 % \raggedbottom 允许页面底部自然变化，保证全文行距一致。
-\raggedbottom
+% 使用 \AtEndOfClass 确保在所有 class 级代码执行完毕后覆盖。
+\AtEndOfClass { \raggedbottom }
 
 % ==========================================
 % Page Layout

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -404,6 +404,12 @@
 % Line spacing
 \setstretch{\tjlinespread}  % 设置全文行距
 
+% 禁止 twoside 模式下拉伸垂直间距
+% book 文档类在 twoside 模式下默认启用 \flushbottom，强制所有页面底部对齐，
+% 这会拉伸 \parskip 等带 stretch 的垂直间距，导致标题附近的空行行距不均匀。
+% \raggedbottom 允许页面底部自然变化，保证全文行距一致。
+\raggedbottom
+
 % ==========================================
 % Page Layout
 % ==========================================


### PR DESCRIPTION

## 概要 | Summary

在 `tongjithesis.cls` 的 General Configurations 区域显式添加 `\AtEndOfClass { \raggedbottom }`，修复 `twoside` 模式下标题附近行距不均匀的问题。

**根因**：`book` 文档类在 `twoside` 下默认启用 `\flushbottom`，拉伸 `\parskip` 等带 stretch 的垂直间距来强制页面底对齐，导致空行间距不均匀。`\raggedbottom` 允许页面底部自然变化，保证全文行距一致。

**实现细节**：使用 `\AtEndOfClass` 包裹 `\raggedbottom`，确保在所有 class 级代码（包括 ctexbook 及其钩子）执行完毕后才覆盖 `\flushbottom` 默认行为。

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [ ] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

Closes #117

## 截图 | Screenshots

仅新增一行 `\AtEndOfClass { \raggedbottom }`，不涉及模板输出外观变化。
