### PR TITLE
feat: switch bibliography to GB/T 7714-2025

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep pinned GitHub Actions versions up to date (grouped into one monthly PR).
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -24,16 +24,16 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -115,7 +115,7 @@ jobs:
           - Compliant with Tongji University's official undergraduate thesis requirements
           - Support for both one-sided and two-sided printing
           - Comprehensive formatting for title page, abstract, table of contents, chapters, etc.
-          - Customized citation styles that comply with Chinese GB/T 7714-2015 standard
+          - Customized citation styles that comply with Chinese GB/T 7714-2025 standard
           - Support for code listings with syntax highlighting (minted or listings)
           - Integration of mathematical formulas, figures, tables, and algorithms
 
@@ -141,7 +141,7 @@ jobs:
           ```latex
           \documentclass[oneside]{tongjithesis}  % Use 'twoside' for double-sided printing
 
-          \tjbibresource{references.bib}
+          \tjbibresource{bib/note.bib}
 
           \school{计算机科学与技术学院}
           \major{计算机科学与技术}
@@ -212,7 +212,7 @@ jobs:
             biblatex=true,
           ]{tongjithesis}
 
-          \tjbibresource{references.bib}
+          \tjbibresource{bib/note.bib}
 
           % Set thesis information
           \school{计算机科学与技术学院}
@@ -418,7 +418,7 @@ jobs:
       PACKAGE_VERSION: ${{ needs.package.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Check if release already exists
         id: check
@@ -503,7 +503,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.PACKAGE_VERSION }}
           name: "TongjiThesis v${{ env.PACKAGE_VERSION }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -134,7 +134,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install TeX Live
         id: setup-tl
@@ -201,7 +201,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Python for minted
         if: matrix.pygments
@@ -350,7 +350,7 @@ jobs:
           - field: humanities
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install TeX Live
         uses: tex-live/setup-texlive-action@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,6 @@
 | 2022.05 | [skyleaworlder](https://github.com/skyleaworlder) | 开始贡献，整合进 [TJ-CSCCG](https://github.com/TJ-CSCCG)，持续更新改进                                                                                                                                   |
 | 2023.04 | [RizhongLin](https://github.com/RizhongLin)       | 开始贡献，负责项目维护和更新                                                                                                                                                                             |
 | 2025.04 | —                                                 | 实现基于键值对的类选项，支持更灵活的配置                                                                                                                                                                 |
-| 2026    | —                                                 | 迁移至 `ctexbook` 基类，全面对齐 2026 版撰写规范；新增 `biblatex`/`bibtex` 双后端、理工/文科双编号体系（`field`）、信息说明页（`\MakeInfoPage`）、跨页代码环境（`longlisting`）；CI 升级至 TeX Live 2026 |
+| 2026    | —                                                 | 迁移至 `ctexbook` 基类，全面对齐 2026 版撰写规范；新增 `biblatex`/`bibtex` 双后端、理工/文科双编号体系（`field`）、信息说明页（`\MakeInfoPage`）、跨页代码环境（`longlisting`）；参考文献样式升级至 GB/T 7714-2025（新增 `@preprint` 预印本类型示例）；CI 升级至 TeX Live 2026 |
 
 我们非常感谢以上贡献者的付出。如果您觉得本项目对您的毕业设计或论文有所帮助，希望您可以在致谢部分提及。

--- a/README-EN.md
+++ b/README-EN.md
@@ -32,6 +32,15 @@ LaTeX template for Tongji University undergraduate thesis (design).
 
 > [!TIP]
 > This template is tested against **TeX Live 2026** in CI. If you encounter unexplained compilation errors locally, please check and upgrade your TeX Live to 2026 first.
+>
+> The bibliography follows GB/T 7714-2025. If the build reports the `gb7714-2025` style or `gbt7714-2025-numeric.bst` as *not found*, your local `biblatex-gb7714-2015` / `gbt7714` packages predate the 2025 styles — update them (requires TeX Live ≥ 2026):
+>
+> ```bash
+> tlmgr update --self                         # run first if tlmgr asks to self-update
+> tlmgr update gbt7714 biblatex-gb7714-2015
+> ```
+>
+> On macOS / Linux system-wide installs, prefix the commands with `sudo`; on Windows, run them from an **Administrator** command prompt (no `sudo`). MiKTeX users: update these packages via the MiKTeX Console instead.
 
 ## Usage
 
@@ -114,7 +123,7 @@ Configure in `main.tex` via `\documentclass`:
   algo=algpseudocode,   % algpseudocode (default): algorithm+algorithmicx; algorithm2e: standalone algorithm2e package
 ]{tongjithesis}
 
-\tjbibresource{bib/note.bib}  % Specify bib files (supports multiple, comma-separated)
+\tjbibresource{bib/note.bib}  % Bib database (supports multiple, comma-separated); styled per GB/T 7714-2025
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@
 
 > [!TIP]
 > 本模板的 CI 基于 **TeX Live 2026** 进行测试。如果您在本地编译时遇到难以解释的编译错误，请首先检查并升级您的 TeX Live 至 2026 版本。
+>
+> 参考文献样式遵循 GB/T 7714-2025。若编译报 `gb7714-2025` 样式或 `gbt7714-2025-numeric.bst` 未找到，说明本地 `biblatex-gb7714-2015` / `gbt7714` 宏包早于 2025 样式，更新即可（需 TeX Live ≥ 2026）：
+>
+> ```bash
+> tlmgr update --self                         # tlmgr 提示需自更新时先执行
+> tlmgr update gbt7714 biblatex-gb7714-2015
+> ```
+>
+> macOS / Linux 系统级安装需在命令前加 `sudo`；Windows 用户请在**管理员权限**的命令行中运行（无需 `sudo`）。若使用 MiKTeX，请改用 MiKTeX Console 更新上述宏包。
 
 ## 使用方法
 
@@ -114,7 +123,7 @@ make wordcount          # wordcount
   algo=algpseudocode,   % algpseudocode（默认）：algorithm+algorithmicx；algorithm2e：独立 algorithm2e 宏包
 ]{tongjithesis}
 
-\tjbibresource{bib/note.bib}  % 指定参考文献数据库文件（支持多文件，逗号分隔）
+\tjbibresource{bib/note.bib}  % 参考文献数据库（支持多文件，逗号分隔）；样式遵循 GB/T 7714-2025
 ```
 
 > [!NOTE]

--- a/bib/note.bib
+++ b/bib/note.bib
@@ -265,14 +265,112 @@
 % ===== 预印本 =====
 
 @preprint{preprint1,
-  author        = {{DeepSeek-AI}},
-  title         = {DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning},
-  eprint        = {2501.12948},
+  author        = {{DeepSeek-AI} and Xu, Anyi and Lin, Bangcai and
+                   Xue, Bing and Wang, Bingxuan and Xu, Bingzheng and
+                   Wu, Bochao and Zhang, Bowei and Lin, Chaofan and
+                   Dong, Chen and Ling, Chenchen and Lu, Chengda and
+                   Zhao, Chenggang and Deng, Chengqi and Hou, Chengyu and
+                   Xu, Chenhao and Shao, Chenze and Ruan, Chong and
+                   Sun, Conner and Dai, Damai and Guo, Daya and
+                   Yang, Dejian and Chen, Deli and Li, Donghao and
+                   Ji, Dongjie and Li, Erhang and Wei, Fang and
+                   Lin, Fangyun and Yuan, Fangzhou and Xia, Feiyu and
+                   Dai, Fucong and Hao, Guangbo and Chen, Guanting and
+                   Cao, Guoai and Meng, Guolai and Li, Guowei and Yu, Han and
+                   Zhang, Han and Xu, Hanwei and Li, Hao and Liang, Haofen and
+                   Zhang, Haoling and Luo, Haoming and Wei, Haoran and
+                   Yuan, Haotian and Zhang, Haowei and Luo, Haowen and
+                   Chen, Haoyu and Ji, Haozhe and Zhang, Hengqing and
+                   Ding, Honghui and Tang, Hongxuan and Cao, Huanqi and
+                   Gao, Huazuo and Qu, Hui and Zeng, Hui and Yang, J. and
+                   Zhu, J. Q. and Luo, Jia and Song, Jia and Yu, Jia and
+                   Huang, Jialiang and Cai, Jialu and Liang, Jian and
+                   Zhou, Jiangting and Ye, Jiasheng and Li, Jiashi and
+                   Xu, Jiaxin and Hu, Jiewen and Yang, Jieyu and Chen, Jin and
+                   Yan, Jin and Chen, Jingchang and Zhou, Jingli and
+                   Xiang, Jingting and Yuan, Jingyang and Cheng, Jingyuan and
+                   Zhou, Jingzi and Zhu, Jinhua and Yu, Jiping and
+                   Sun, Joseph and Ran, Jun and Jiang, Junguang and
+                   Qiu, Junjie and Li, Junlong and Zheng, Junmin and
+                   Song, Junxiao and Dong, Kai and Gao, Kaige and
+                   Guan, Kang and Zhou, Kexing and Huang, Kezhao and
+                   Yu, Kuai and Wang, Lean and Zhang, Lecong and Wang, Lei and
+                   Xia, Leyi and Zhang, Li and Zhao, Liang and Guo, Lihua and
+                   Luo, Lingxiao and Ma, Linwang and Zhu, Linyan and
+                   Wang, Litong and Cai, Liyu and Zhang, Liyue and
+                   Chen, Longhao and Di, M. S. and Xu, M. Y. and Mei, Max and
+                   Wang, Miaojun and Zhang, Mingchuan and Zhang, Minghua and
+                   Tang, Minghui and Li, Mingming and Zhou, Mingxu and
+                   Han, Minmin and Wang, Ning and Huang, Panpan and
+                   Wang, Panpan and Cong, Peixin and Wang, Peiyi and
+                   Zhang, Peng and Wang, Qiancheng and Zhu, Qihao and
+                   Li, Qingyang and Chen, Qinyu and Du, Qiushi and
+                   Jiang, Qiwei and Tian, Rui and Xu, Ruifan and
+                   Lu, Ruijie and Xu, Ruiling and Ge, Ruiqi and
+                   Zhang, Ruisong and Pan, Ruizhe and Wang, Runji and
+                   Chen, Runqian and Yin, Runqiu and Xu, Runxin and
+                   Shen, Ruomeng and Zhang, Ruoyu and Chen, Ruyi and
+                   Liu, S. H. and Lu, Shanghao and Sun, Shangmian and
+                   Zhou, Shangyan and Chen, Shanhuang and Cai, Shaofei and
+                   Nie, Shaoheng and Wu, Shaoqing and Chen, Shaoyuan and
+                   Hu, Shengding and Liu, Shengyu and Hu, Shiqiang and
+                   Ma, Shirong and Wang, Shiyu and Yu, Shuiping and
+                   Zhou, Shunfeng and Pan, Shuting and Yu, Shuying and
+                   Zhou, Songyang and Ni, Tao and Yun, Tao and Jin, Tian and
+                   Pei, Tian and Ye, Tian and Lin, Tianle and Ji, Tianran and
+                   Cui, Tianyi and Yue, Tianyuan and Yu, Tingting and
+                   Wang, Tun and Zhang, W. and Xiao, W. L. and
+                   Zeng, Wangding and An, Wei and Zhao, Weilin and
+                   Liu, Wen and Liang, Wenfeng and Pang, Wenjie and
+                   Luo, Wenjing and Yao, Wenjing and Gao, Wenjun and
+                   Yang, Wenkai and Huang, Wenlve and Hou, Wenqing and
+                   Zhang, Wentao and Ma, Wenting and Gao, Xi and He, Xiang and
+                   Wang, Xiangwen and Wang, Xianzu and Bi, Xiao and
+                   Liu, Xiaodong and Wang, Xiaohan and Chen, Xiaokang and
+                   Zhang, Xiaokang and Nie, Xiaotao and Sun, Xiaowen and
+                   Wang, Xiaoxiang and Cheng, Xin and Liu, Xin and
+                   Xie, Xin and Liu, Xingchao and Liu, Xingchen and
+                   Yu, Xingkai and Li, Xingyou and Yang, Xinyu and
+                   Zhang, Xinyu and Chen, Xu and Wang, Xuanyu and
+                   Su, Xuecheng and Chen, Xueyin and Lin, Xuheng and
+                   Fu, Xuwei and Yan, Y. C. and Wang, Y. Q. and Ma, Y. W. and
+                   Luo, Yanfeng and Zhang, Yang and Xu, Yanhong and
+                   Ma, Yanru and Huang, Yanwen and Li, Yao and Xu, Yao and
+                   Zhao, Yao and Sun, Yaofeng and Wang, Yaohui and
+                   Qian, Yi and Shao, Yi and Yu, Yi and Zhang, Yichao and
+                   Ding, Yifan and Shi, Yifan and Wu, Yijia and
+                   Xiong, Yiliang and Ma, Yiling and He, Ying and
+                   Tang, Ying and Zhou, Ying and Luo, Yingjia and
+                   Zhong, Yinmin and Piao, Yishi and Wang, Yisong and
+                   Zhang, Yixiang and Chen, Yixiao and Tan, Yixuan and
+                   Wei, Yixuan and Ma, Yiyang and Liu, Yiyuan and
+                   Yang, Yonglun and Guo, Yongqiang and Wu, Yongtong and
+                   Wu, Yu and Li, YuKun and Cheng, Yuan and Ou, Yuan and
+                   Xu, Yuanfan and Li, Yuanhao and Wang, Yuduan and
+                   Yang, Yuehan and Xu, Yuer and Wu, Yuhan and Meng, Yuhao and
+                   Zou, Yuheng and Zha, Yukun and Xiong, Yunfan and
+                   Chen, Yupeng and Lin, Yuping and Cao, Yuqian and
+                   Wang, Yuqian and Zhang, Yushun and Yan, Yuting and
+                   Lin, Yutong and Gu, Yuxian and Luo, Yuxiang and
+                   You, Yuxiang and Liu, Yuxuan and Zhou, Yuxuan and
+                   Zhou, Yuyang and Huang, Yuzhen and Wu, Z. F. and
+                   Wang, Zehao and Zhao, Zehua and Ren, Zehui and
+                   Zhang, Zekai and Sha, Zhangli and Fu, Zhe and Ju, Zhe and
+                   Xu, Zhean and Xie, Zhenda and Zhang, Zhengyan and
+                   Gao, Zheren and Hao, Zhewen and Gou, Zhibin and
+                   Ma, Zhicheng and Yan, Zhigang and Shao, Zhihong and
+                   Huang, Zhixian and Chen, Zhixuan and Wu, Zhiyu and
+                   Ren, Zhizhou and Wu, Zhongyu and Li, Zhuoshu and
+                   Zhang, Zhuping and Xu, Zian and Wang, Zihao and
+                   Qu, Zihua and Gu, Zihui and Zhu, Zijia and Li, Zilin and
+                   Zhang, Zipeng and Xie, Ziwei and Gao, Ziyi and
+                   Wan, Ziyi and Pan, Zizheng and Yao, Zongqing},
+  title         = {{DeepSeek}-{V4}: Towards Highly Efficient Million-Token Context Intelligence},
+  eprint        = {2606.19348},
   archiveprefix = {arXiv},
-  date          = {2025-01-22},
-  url           = {https://arxiv.org/abs/2501.12948},
-  urldate       = {2026-07-03},
-  pubstate      = {prepublished}
+  date          = {2026-04},
+  url           = {https://arxiv.org/abs/2606.19348},
+  urldate       = {2026-07-03}
 }
 
 @preprint{preprint2,
@@ -284,6 +382,5 @@
   url           = {https://zsyyb.cn/abs/202408.01096},
   urldate       = {2024-09-30},
   cstr          = {32012.36.PSSXiv.202408.01096},
-  pubstate      = {prepublished},
   langid        = {chinese}
 }

--- a/bib/note.bib
+++ b/bib/note.bib
@@ -238,12 +238,12 @@
 % ===== 网络资源 =====
 
 @online{online1,
-  author  = {中国国家标准化管理委员会},
+  author  = {全国信息与文献标准化技术委员会},
   title   = {信息与文献\quad 参考文献著录规则},
-  date    = {2015-05-15},
-  url     = {https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=7FA63E9BBA56E60471AEDAEBDE44B14C},
-  urldate = {2026-03-26},
-  note    = {GB/T 7714-2015}
+  date    = {2025-12-02},
+  url     = {https://std.samr.gov.cn/gb/search/gbDetailed?id=4507EFE13D37CB6AE06397BE0A0A601F},
+  urldate = {2026-07-03},
+  note    = {GB/T 7714-2025}
 }
 
 @online{online3,
@@ -260,4 +260,30 @@
   year    = {2026},
   url     = {https://pytorch.org/docs/stable/index.html},
   urldate = {2026-03-26}
+}
+
+% ===== 预印本 =====
+
+@preprint{preprint1,
+  author        = {{DeepSeek-AI}},
+  title         = {DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning},
+  eprint        = {2501.12948},
+  archiveprefix = {arXiv},
+  date          = {2025-01-22},
+  url           = {https://arxiv.org/abs/2501.12948},
+  urldate       = {2026-07-03},
+  pubstate      = {prepublished}
+}
+
+@preprint{preprint2,
+  author        = {肖玲 and 张雪 and 王永},
+  title         = {数据要素的统计测算方法探究},
+  eprint        = {202408.01096},
+  archiveprefix = {PSSXiv},
+  date          = {2024-08-14},
+  url           = {https://zsyyb.cn/abs/202408.01096},
+  urldate       = {2024-09-30},
+  cstr          = {32012.36.PSSXiv.202408.01096},
+  pubstate      = {prepublished},
+  langid        = {chinese}
 }

--- a/chapters/05_reference.tex
+++ b/chapters/05_reference.tex
@@ -7,14 +7,14 @@
 在学术论文或科技报告中，通常需要引用相关文献以支持观点或论证。为了方便读者查阅，我们需要在论文中标注参考文献。在 \LaTeX\ 中，可使用 \verb|\cite| 命令引用参考文献。参考文献的外观应符合国标 GB/T 7714，本模板提供两种方式：
 \begin{enumerate}
     \item 使用 \BibTeX{} 配合 \pkg{gbt7714} 宏包
-    \item 使用 \BibLaTeX{} 配合 \pkg{biblatex-gb7714-2015} 样式包
+    \item 使用 \BibLaTeX{} 配合 \pkg{biblatex-gb7714-2015} 样式包（其 \texttt{gb7714-2025} 样式实现 GB/T 7714-2025）
 \end{enumerate}
 其中，\BibLaTeX{} 方案功能更为丰富（支持 \cs{fullcite}、\cs{footfullcite} 等命令），且由 \texttt{biber} 引擎驱动，对 Unicode 和中文文献支持更好，是本模板的\textbf{默认推荐}方案。不过，\texttt{biber} 的编译速度较 \texttt{bibtex} 慢，在文献条目较多时差异尤为明显。\BibTeX{} 方案编译更快，且部分期刊投稿仍要求使用，如对编译速度敏感或有投稿需求，可设置 \texttt{biblatex=false} 切换至 \BibTeX{} 方案。
 
 两种方式都能实现符合国标的参考文献格式。可通过文档类选项 \texttt{biblatex=true}（默认）或 \texttt{biblatex=false} 进行切换。无论选择哪种方式，均使用 \cs{tjbibresource} 命令在导言区指定参考文献数据库文件，使用 \cs{makereferences} 命令在正文中输出参考文献列表：
 
 \begin{Verbatim}
-\tjbibresource{bib/references.bib}  % 导言区指定 .bib 文件
+\tjbibresource{bib/note.bib}        % 导言区指定 .bib 文件
 ...
 \makereferences                     % 正文中输出参考文献
 \end{Verbatim}
@@ -41,6 +41,7 @@
   \item 期刊中析出的文献\cite{qin2021,article1,guo_deepseek-r1_2025}
   \item 报纸中析出的文献\cite{newspaper1,newspaper2}
   \item 电子文献\cite{online1,online2,online3}
+  \item 预印本\cite{preprint1,preprint2}
 \end{itemize}
 
 可使用 \verb|\nocite{key1,key2,key3...}| 将参考文献条目加入文献表中，但不在正文中引用。使用 \verb|\nocite{*}| 可将参考文献数据库中的所有条目加入文献表中。
@@ -48,7 +49,7 @@
 在编写 \texttt{.bib} 文件时，需注意以下常见问题：
 \begin{itemize}
   \item 每个条目的键值（如 \texttt{book1}）在整个 \texttt{.bib} 文件中必须唯一；
-  \item 常见的条目类型包括 \texttt{@book}（图书）、\texttt{@article}（期刊论文）、\texttt{@inproceedings}（会议论文）、\texttt{@phdthesis}（博士论文）、\texttt{@mastersthesis}（硕士论文）、\texttt{@online}（网络资源）等；
+  \item 常见的条目类型包括 \texttt{@book}（图书）、\texttt{@article}（期刊论文）、\texttt{@inproceedings}（会议论文）、\texttt{@phdthesis}（博士论文）、\texttt{@mastersthesis}（硕士论文）、\texttt{@online}（网络资源）、\texttt{@preprint}（预印本，GB/T 7714-2025 新增）等；
   \item 中文作者姓名之间使用 \texttt{and} 连接，而非顿号或逗号；
   \item 建议使用 Zotero、Mendeley 等软件管理参考文献，可自动生成规范的 \texttt{.bib} 文件。
 \end{itemize}

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -336,6 +336,7 @@
   \RequirePackage[
     backend=biber,
     style=gb7714-2025,
+    gbpunctwidth=mixed,   % GB/T 7714-2025：除“.”与“[]”用半角外，其余标识符用全角
     natbib=true,
   ]{biblatex}
   % 参考文献序号左对齐至页边距，悬挂统一为 0.74cm（与 Word 模板一致）。
@@ -357,7 +358,7 @@
     {\endlist}
     {\item}
 \else
-  \RequirePackage[sort&compress]{gbt7714}
+  \RequirePackage[sort&compress, bibpunct=GB]{gbt7714}   % GB=全角标点（除“.”“[]”外），与 biblatex 的 gbpunctwidth=mixed 对齐
   \bibliographystyle{gbt7714-2025-numeric}
   \setlength{\bibsep}{3pt}
   % 参考文献序号左对齐至页边距，悬挂统一为 0.74cm（与 Word 模板一致）。

--- a/style/tongjithesis.cls
+++ b/style/tongjithesis.cls
@@ -328,10 +328,14 @@
 % ==========================================
 % Bibliography Configuration
 % ==========================================
+% 参考文献样式遵循 GB/T 7714-2025。所需宏包版本（均随 TeX Live 2026+ 分发）：
+%   - biblatex 路径：biblatex-gb7714-2015 >= v1.1w（提供 gb7714-2025 样式）
+%   - bibtex   路径：gbt7714 >= v2.2.0（提供 gbt7714-2025-numeric.bst）
+% 版本过旧会报「style/bst not found」错误；升级步骤见 README「快速开始」提示。
 \iftongjithesis@biblatex
   \RequirePackage[
     backend=biber,
-    style=gb7714-2015,
+    style=gb7714-2025,
     natbib=true,
   ]{biblatex}
   % 参考文献序号左对齐至页边距，悬挂统一为 0.74cm（与 Word 模板一致）。
@@ -354,7 +358,7 @@
     {\item}
 \else
   \RequirePackage[sort&compress]{gbt7714}
-  \bibliographystyle{gbt7714-numerical}
+  \bibliographystyle{gbt7714-2025-numeric}
   \setlength{\bibsep}{3pt}
   % 参考文献序号左对齐至页边距，悬挂统一为 0.74cm（与 Word 模板一致）。
   % gbt7714 已将 \@biblabel 改为 [#1]\hfill（左对齐）。natbib（gbt7714 内部加载）


### PR DESCRIPTION
## 概要 | Summary

将参考文献样式从 GB/T 7714-2015 升级至 **GB/T 7714-2025**（新国标 2025-12-02 发布、2026-07-01 实施，全部代替 2015 版），两种后端同步切换，并顺带刷新 CI 基础设施。

**样式切换（两后端）**
- biblatex：`style=gb7714-2015` → `gb7714-2025`
- bibtex：`gbt7714-numerical` → `gbt7714-2025-numeric`

**全角标点（GB/T 7714-2025 §7 著录用符号）**
标准原文：`".""[ ]" 用半角符号，其他标识符号用全角符号`。据此在两后端显式启用「混合宽度」，使二者输出一致且合规：
- biblatex：`gbpunctwidth=mixed`
- bibtex：`bibpunct=GB`

此前 biblatex 路径对中文条目输出全半角（2015 观感），不符合 2025 标准；现两后端均为 `严蔚敏，吴伟民. 数据结构[M]. …北京：清华大学出版社，1997.`（`，：（）` 全角，`. [ ]` 半角）。

**预印本示例（2025 新增 `@preprint` 类型）**
`bib/note.bib` 新增两条预印本示例，`@preprint` 类型两后端通用：
- arXiv：DeepSeek-V4（`arXiv:2606.19348`），完整作者名单按其他条目风格折行，题名专有名词加花括号保护
- 国内 PSSXiv：真实论文，含 2025 新增的 `cstr`（中国科技资源标识符）

均渲染为 `[PP/OL]`。同时将「国标自身」示例条目（`online1`）从 2015 版更新为 GB/T 7714-2025。

**文档**
`chapters/05_reference.tex` 说明 `@preprint`、引用新条目、修正 `references.bib` → `bib/note.bib`；`README(-EN)` 增补 GB/T 7714-2025 说明与跨平台 `tlmgr` 排障步骤（macOS/Linux/Windows/MiKTeX）；`CONTRIBUTING.md` 更新项目历史。

**CI 基础设施**
升级落后的 GitHub Actions（`checkout` v7、`configure-pages` v6、`upload-pages-artifact` v5、`action-gh-release` v3）；新增 `.github/dependabot.yml`（github-actions，月度分组更新）。

依赖：`biblatex-gb7714-2015` ≥ v1.1w、`gbt7714` ≥ v2.2.0（随 TeX Live 2026+ 分发）。本地已用 `make` 验证两种后端均编译通过、标点与预印本渲染正确。

> [!NOTE]
> GitHub Actions 大版本升级（`checkout@v7` 的 `workflow_run`/fork-PR 加固、`action-gh-release@v3` 的 Node 20→24）尚未经 CI 实跑验证——本 PR 的 CI 即为验证手段，合并前请确认 `test`、`release`、`jekyll-gh-pages` 三条流水线均为绿色。

## 检查清单 | Checklist

- [x] 已通读[贡献指南](https://github.com/TJ-CSCCG/TongjiThesis/blob/master/CONTRIBUTING.md)。
- [x] 如涉及模板功能变更，已编写注释并更新对应文档。
- [x] 如涉及模板功能变更，已尽可能在各平台上进行测试。

## 关联 Issue | Related Issues

Closes #123
